### PR TITLE
Included TEnum type name to make not found exception messages more descriptive

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -1,0 +1,3 @@
+[*.cs]
+indent_style = space
+indent_size = 4

--- a/src/SmartEnum.UnitTests/SmartEnumFromName.cs
+++ b/src/SmartEnum.UnitTests/SmartEnumFromName.cs
@@ -44,5 +44,24 @@ namespace SmartEnum.UnitTests
         {
             Assert.Throws<SmartEnumNotFoundException>(() => TestEnum.FromName("Doesn't Exist"));
         }
+
+        [Fact]
+        public void ThrowsWithExpectedMessageGivenNonMatchingString()
+        {
+            string name = "Doesn't Exist";
+            string expected = $"No TestEnum with Name \"{name}\" found.";
+            string actual = "";
+
+            try
+            {
+                var testEnum = TestEnum.FromName(name);
+            }
+            catch (SmartEnumNotFoundException ex)
+            {
+                actual = ex.Message;
+            }
+
+            Assert.Equal(expected, actual);
+        }
     }
 }

--- a/src/SmartEnum.UnitTests/SmartEnumFromValue.cs
+++ b/src/SmartEnum.UnitTests/SmartEnumFromValue.cs
@@ -17,5 +17,23 @@ namespace SmartEnum.UnitTests
         {
             Assert.Throws<SmartEnumNotFoundException>(() => TestEnum.FromValue(-1));
         }
+
+        [Fact]
+        public void ThrowsWithExpectedMessageGivenNonMatchingValue()
+        {
+            string expected = $"No option with Value -1 found.";
+            string actual = "";
+
+            try
+            {
+                var testEnum = TestEnum.FromValue(-1);
+            }
+            catch (SmartEnumNotFoundException ex)
+            {
+                actual = ex.Message;
+            }
+
+            Assert.Equal(expected, actual);
+        }
     }
 }

--- a/src/SmartEnum.UnitTests/SmartEnumFromValue.cs
+++ b/src/SmartEnum.UnitTests/SmartEnumFromValue.cs
@@ -21,7 +21,7 @@ namespace SmartEnum.UnitTests
         [Fact]
         public void ThrowsWithExpectedMessageGivenNonMatchingValue()
         {
-            string expected = $"No option with Value -1 found.";
+            string expected = $"No TestEnum with Value -1 found.";
             string actual = "";
 
             try

--- a/src/SmartEnum/SmartEnum.cs
+++ b/src/SmartEnum/SmartEnum.cs
@@ -51,7 +51,7 @@ namespace Ardalis.SmartEnum
             var result = List.FirstOrDefault(item => string.Equals(item.Name, name, StringComparison.OrdinalIgnoreCase));
             if(result == null)
             {
-                throw new SmartEnumNotFoundException($"No option with Name \"{name}\" found.");
+                throw new SmartEnumNotFoundException($"No {typeof(TEnum).Name} with Name \"{name}\" found.");
             }
             return result;
         }
@@ -63,7 +63,7 @@ namespace Ardalis.SmartEnum
             var result = List.FirstOrDefault(item => EqualityComparer<TValue>.Default.Equals(item.Value, value));
             if (result == null)
             {
-                throw new SmartEnumNotFoundException($"No option with Value {value} found.");
+                throw new SmartEnumNotFoundException($"No {typeof(TEnum).Name} with Value {value} found.");
             }
             return result;
         }

--- a/src/SmartEnum/SmartEnum.cs
+++ b/src/SmartEnum/SmartEnum.cs
@@ -63,7 +63,7 @@ namespace Ardalis.SmartEnum
             var result = List.FirstOrDefault(item => EqualityComparer<TValue>.Default.Equals(item.Value, value));
             if (result == null)
             {
-                throw new SmartEnumNotFoundException($"No option with Value {{value}} found.");
+                throw new SmartEnumNotFoundException($"No option with Value {value} found.");
             }
             return result;
         }


### PR DESCRIPTION
Replaced "option" in the SmartEnumNotFoundException messages with the TEnum type name to make the exception more descriptive.