### PR TITLE
Scott: SmartEnum Implicit Value Conversion

### DIFF
--- a/src/SmartEnum.UnitTests/SmartEnumFromName.cs
+++ b/src/SmartEnum.UnitTests/SmartEnumFromName.cs
@@ -1,5 +1,4 @@
-using Ardalis.SmartEnum;
-using SmartEnum.Exceptions;
+﻿using SmartEnum.Exceptions;
 using System;
 using Xunit;
 

--- a/src/SmartEnum.UnitTests/SmartEnumFromValue.cs
+++ b/src/SmartEnum.UnitTests/SmartEnumFromValue.cs
@@ -1,5 +1,4 @@
-using Ardalis.SmartEnum;
-using SmartEnum.Exceptions;
+﻿using SmartEnum.Exceptions;
 using Xunit;
 
 namespace SmartEnum.UnitTests

--- a/src/SmartEnum.UnitTests/SmartEnumImplicitValueConversion.cs
+++ b/src/SmartEnum.UnitTests/SmartEnumImplicitValueConversion.cs
@@ -1,0 +1,15 @@
+﻿using Xunit;
+
+namespace SmartEnum.UnitTests
+{
+    public class SmartEnumImplicitValueConversion
+    {
+        [Fact]
+        public void ReturnsValueOfGivenEnum()
+        {
+            int result = TestEnum.One;
+
+            Assert.Equal(TestEnum.One.Value, result);
+        }
+    }
+}

--- a/src/SmartEnum.UnitTests/SmartEnumList.cs
+++ b/src/SmartEnum.UnitTests/SmartEnumList.cs
@@ -1,8 +1,7 @@
-using Xunit;
+﻿using Xunit;
 
 namespace SmartEnum.UnitTests
 {
-
     public class SmartEnumList
     {
         [Fact]

--- a/src/SmartEnum.UnitTests/SmartEnumToString.cs
+++ b/src/SmartEnum.UnitTests/SmartEnumToString.cs
@@ -1,4 +1,4 @@
-using Xunit;
+﻿using Xunit;
 
 namespace SmartEnum.UnitTests
 {

--- a/src/SmartEnum/SmartEnum.cs
+++ b/src/SmartEnum/SmartEnum.cs
@@ -1,9 +1,9 @@
-﻿using System;
+﻿using Ardalis.GuardClauses;
+using SmartEnum.Exceptions;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using Ardalis.GuardClauses;
-using SmartEnum.Exceptions;
 
 namespace Ardalis.SmartEnum
 {
@@ -28,13 +28,7 @@ namespace Ardalis.SmartEnum
             .ToList();
         }
 
-        public static List<TEnum> List
-        {
-            get
-            {
-                return _list.Value;
-            }
-        }
+        public static List<TEnum> List => _list.Value;
 
         public string Name { get; }
         public TValue Value { get; }
@@ -58,7 +52,7 @@ namespace Ardalis.SmartEnum
 
         public static TEnum FromValue(TValue value)
         {
-            // Can't use == to compare generics unless we constrain TValue to "class", 
+            // Can't use == to compare generics unless we constrain TValue to "class",
             // which we don't want because then we couldn't use int.
             var result = List.FirstOrDefault(item => EqualityComparer<TValue>.Default.Equals(item.Value, value));
             if (result == null)
@@ -69,5 +63,7 @@ namespace Ardalis.SmartEnum
         }
 
         public override string ToString() => $"{Name} ({Value})";
+
+        public static implicit operator TValue(SmartEnum<TEnum, TValue> smartEnum) => smartEnum.Value;
     }
 }

--- a/src/SmartEnum/SmartEnum.csproj
+++ b/src/SmartEnum/SmartEnum.csproj
@@ -16,6 +16,7 @@
     <Version>1.0.2</Version>
     <AssemblyName>Ardalis.SmartEnum</AssemblyName>
     <PackageIconUrl>https://user-images.githubusercontent.com/782127/33497760-facf6550-d69c-11e7-94e4-b3856da259a9.png</PackageIconUrl>
+    <RootNamespace>Ardalis.SmartEnum</RootNamespace>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard1.1|AnyCPU'">


### PR DESCRIPTION
Allows converting from `SmartEnum<TEnum, TValue>` to `TValue`. Useful for situations that crop up when using C# `enum` where you need the integer value.

    private void SomeMethod(int enumValue) { }

    // Elsewhere in code
    SomeMethod(TestEnum.One); // Now you don't have to write TestEnum.One.Value

This is particularly useful when adapting legacy code, transforming `enum`s into `SmartEnum`s.

Also in this PR:
* Root namespace of `SmartEnum` updated to match AssemblyName and namespace use in code.
* `using` removal/sorting
* whitespace fix