### PR TITLE
Add explicit operator

### DIFF
--- a/src/SmartEnum.UnitTests/SmartEnum.UnitTests.csproj
+++ b/src/SmartEnum.UnitTests/SmartEnum.UnitTests.csproj
@@ -1,19 +1,14 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-
     <IsPackable>false</IsPackable>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\SmartEnum\SmartEnum.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/SmartEnum.UnitTests/SmartEnumExplicitConversion.cs
+++ b/src/SmartEnum.UnitTests/SmartEnumExplicitConversion.cs
@@ -1,0 +1,15 @@
+﻿using Xunit;
+
+namespace SmartEnum.UnitTests
+{
+    public class SmartEnumExplicitConversion
+    {
+        [Fact]
+        public void ReturnsEnumFromGivenValue()
+        {
+            var result = (TestEnum) 1;
+
+            Assert.Equal(TestEnum.One, result);
+        }
+    }
+}

--- a/src/SmartEnum/SmartEnum.cs
+++ b/src/SmartEnum/SmartEnum.cs
@@ -77,5 +77,6 @@ namespace Ardalis.SmartEnum
         public override string ToString() => $"{Name} ({Value})";
 
         public static implicit operator TValue(SmartEnum<TEnum, TValue> smartEnum) => smartEnum.Value;
+        public static explicit operator SmartEnum<TEnum, TValue>(TValue value) => FromValue(value);
     }
 }


### PR DESCRIPTION
Adds an explicit operator to simplify converting a value to a SmartEnum.

```C#
var result = (TestEnum) 1;
```

is the same as:
```C#
var result = TestEnum.FromValue(1);
```