### PR TITLE
Adding protected parameterless constructor so SmartEnums are supporte…

### DIFF
--- a/src/SmartEnum.UnitTests/TestEnum.cs
+++ b/src/SmartEnum.UnitTests/TestEnum.cs
@@ -11,5 +11,10 @@ namespace SmartEnum.UnitTests
         protected TestEnum(string name, int value) : base(name, value)
         {
         }
+
+        private TestEnum() : base()
+        {
+            // required for EF
+        }
     }
 }

--- a/src/SmartEnum/SmartEnum.cs
+++ b/src/SmartEnum/SmartEnum.cs
@@ -39,6 +39,11 @@ namespace Ardalis.SmartEnum
             Value = value;
         }
 
+        protected SmartEnum()
+        {
+            // Required for EF
+        }
+
         public static TEnum FromName(string name)
         {
             Guard.Against.NullOrEmpty(name, nameof(name));


### PR DESCRIPTION
Fix to allow SmartEnums to be properties for EF entities by adding protected parameterless constructor so the derived class can have a private parameterless constructor to make EF happy. :smile: 

Connected to issue https://github.com/ardalis/SmartEnum/issues/15