### PR TITLE
Improve performance of Equals() and GetHashCode()

### DIFF
--- a/src/SmartEnum.UnitTests/SmartEnumEquals.cs
+++ b/src/SmartEnum.UnitTests/SmartEnumEquals.cs
@@ -1,0 +1,74 @@
+using SmartEnum.Exceptions;
+using System;
+using Xunit;
+
+namespace SmartEnum.UnitTests
+{
+    public class SmartEnumEquals
+    {
+        private class TestEnum2 : Ardalis.SmartEnum.SmartEnum<TestEnum2, int>
+        {
+            public static TestEnum2 One = new TestEnum2(nameof(One), 1);
+
+            protected TestEnum2(string name, int value) : base(name, value)
+            {
+            }
+        }
+
+        public static TheoryData<TestEnum, object, bool> EqualsObjectData =>
+            new TheoryData<TestEnum, object, bool>
+        {
+            { TestEnum.One, null, false },
+            { TestEnum.One, TestEnum.One, true },
+            { TestEnum.One, TestEnum2.One, false },
+            { TestEnum.One, TestEnum.Two, false },
+        };
+
+        [Theory]
+        [MemberData(nameof(EqualsObjectData))]
+        public void EqualsObjectReturnsExpected(TestEnum left, object right, bool expected)
+        {
+            Assert.Equal(expected, left.Equals(right));
+        }
+
+        public static TheoryData<TestEnum, TestEnum, bool> EqualsSmartEnumData =>
+            new TheoryData<TestEnum, TestEnum, bool>
+        {
+            { TestEnum.One, null, false },
+            { TestEnum.One, TestEnum.One, true },
+            { TestEnum.One, TestEnum.Two, false },
+        };
+
+        [Theory]
+        [MemberData(nameof(EqualsSmartEnumData))]
+        public void EqualsSmartEnumReturnsExpected(TestEnum left, object right, bool expected)
+        {
+            Assert.Equal(expected, left.Equals(right));
+        }
+
+        public static TheoryData<TestEnum, object, bool> EqualOperatorData =>
+            new TheoryData<TestEnum, object, bool>
+        {
+            { null, null, true },
+            { null, TestEnum.One, false },
+            { TestEnum.One, null, false },
+            { TestEnum.One, TestEnum.One, true },
+            { TestEnum.One, TestEnum2.One, false },
+            { TestEnum.One, TestEnum.Two, false },
+        };
+
+        [Theory]
+        [MemberData(nameof(EqualOperatorData))]
+        public void EqualOperatorReturnsExpected(TestEnum left, object right, bool expected)
+        {
+            Assert.Equal(expected, left == right);
+        }
+
+        [Theory]
+        [MemberData(nameof(EqualOperatorData))]
+        public void NotEqualOperatorReturnsExpected(TestEnum left, object right, bool expected)
+        {
+            Assert.Equal(!expected, left != right);
+        }
+    }
+}

--- a/src/SmartEnum/SmartEnum.cs
+++ b/src/SmartEnum/SmartEnum.cs
@@ -110,7 +110,7 @@ namespace Ardalis.SmartEnum
             }
 
             // Return true if both name and value match
-            return Name == other.Name && EqualityComparer<TValue>.Default.Equals(Value, other.Value);
+            return Name.Equals(other.Name) && EqualityComparer<TValue>.Default.Equals(Value, other.Value);
         }
 
         public static bool operator ==(SmartEnum<TEnum, TValue> left, SmartEnum<TEnum, TValue> right)

--- a/src/SmartEnum/SmartEnum.cs
+++ b/src/SmartEnum/SmartEnum.cs
@@ -80,7 +80,20 @@ namespace Ardalis.SmartEnum
         }
 
         public override string ToString() => $"{Name} ({Value})";
-        public override int GetHashCode() => (Name, Value).GetHashCode();
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                const int HashingBase = (int)2166136261;
+                const int HashingMultiplier = 16777619;
+
+                var hash = HashingBase;
+                hash = (hash * HashingMultiplier) ^ (Object.ReferenceEquals(null, Value) ? 0 : Value.GetHashCode());
+                hash = (hash * HashingMultiplier) ^ (Name is null ? 0 : Name.GetHashCode());
+                return hash;
+            }
+        }   
+
         public override bool Equals(object obj) => (obj is SmartEnum<TEnum, TValue> other) && Equals(other);
 
         public bool Equals(SmartEnum<TEnum, TValue> other)
@@ -97,21 +110,15 @@ namespace Ardalis.SmartEnum
             }
 
             // Return true if both name and value match
-            return (Name, Value).Equals((other.Name, other.Value));
+            return Name == other.Name && EqualityComparer<TValue>.Default.Equals(Value, other.Value);
         }
 
         public static bool operator ==(SmartEnum<TEnum, TValue> left, SmartEnum<TEnum, TValue> right)
         {
-            // Handle same reference, including null
-            if (ReferenceEquals(left, right))
-            {
-                return true;
-            }
-
             // Handle null on left side
             if (left is null)
             {
-                return false;
+                return right is null;
             }
 
             // Equals handles null on right side

--- a/src/SmartEnum/SmartEnum.cs
+++ b/src/SmartEnum/SmartEnum.cs
@@ -80,7 +80,7 @@ namespace Ardalis.SmartEnum
         }
 
         public override string ToString() => $"{Name} ({Value})";
-        public override int GetHashCode() => new { Name, Value }.GetHashCode();
+        public override int GetHashCode() => ( Name, Value ).GetHashCode();
         public override bool Equals(object obj) => Equals(obj as SmartEnum<TEnum, TValue>);
 
         public bool Equals(SmartEnum<TEnum, TValue> other)

--- a/src/SmartEnum/SmartEnum.cs
+++ b/src/SmartEnum/SmartEnum.cs
@@ -80,8 +80,8 @@ namespace Ardalis.SmartEnum
         }
 
         public override string ToString() => $"{Name} ({Value})";
-        public override int GetHashCode() => ( Name, Value ).GetHashCode();
-        public override bool Equals(object obj) => Equals(obj as SmartEnum<TEnum, TValue>);
+        public override int GetHashCode() => (Name, Value).GetHashCode();
+        public override bool Equals(object obj) => (obj is SmartEnum<TEnum, TValue> other) && Equals(other);
 
         public bool Equals(SmartEnum<TEnum, TValue> other)
         {
@@ -96,27 +96,21 @@ namespace Ardalis.SmartEnum
                 return true;
             }
 
-            // If the runtime types are not the same, return false
-            if (GetType() != other.GetType())
-            {
-                return false;
-            }
-
             // Return true if both name and value match
-            return Name == other.Name && EqualityComparer<TValue>.Default.Equals(Value, other.Value);
+            return (Name, Value).Equals((other.Name, other.Value));
         }
 
         public static bool operator ==(SmartEnum<TEnum, TValue> left, SmartEnum<TEnum, TValue> right)
         {
+            // Handle same reference, including null
+            if (ReferenceEquals(left, right))
+            {
+                return true;
+            }
+
             // Handle null on left side
             if (left is null)
             {
-                if (right is null)
-                {
-                    // null == null = true
-                    return true;
-                }
-
                 return false;
             }
 

--- a/src/SmartEnum/SmartEnum.csproj
+++ b/src/SmartEnum/SmartEnum.csproj
@@ -28,8 +28,4 @@
     <PackageReference Include="Ardalis.GuardClauses" Version="1.2.3" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)'!='netstandard2.0'">
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-  </ItemGroup>
-
 </Project>

--- a/src/SmartEnum/SmartEnum.csproj
+++ b/src/SmartEnum/SmartEnum.csproj
@@ -28,4 +28,8 @@
     <PackageReference Include="Ardalis.GuardClauses" Version="1.2.3" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)'!='netstandard2.0'">
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
`SmartEnum.GetHashCode()` is implemented by calling `GetHashCode()` of a new instance of an anonymous type containing `Name` and `Value`. This is a neat trick but anonymous types are reference-types. This means that it's allocated on the heap and the call to the method is a `callvirt`.

`ValueTuple`s are value-types so they are allocated on the stack and method calls are direct.

Check the IL differences in [SharpLab](https://sharplab.io/#v2:C4LglgNgPgAgDAAhgRgNwFgBQWYGYkBMCAygLYCGATsAKIB2ArqQgN5YIcLud5LKIA5cqQCmrBAHMRwVAgC+3DrzB1gCAGrkIDMS0nTZAB0oB7YCIDG5gCYIAzgfmKumTknwq1AcWkBBOiZ0AJ6kJgx2ABLkdgAWAMIm1iIAFACUCAC8AHwubm50IgDu4kKiADQaWjryAHQ+wFGxCUlpGK6czsqqCPWa2iIAKgyGECKN8Ykp6dm5eRzJCKUiFX3VqXXS481TbXJAA===).

[BenchmarkDotNet](https://benchmarkdotnet.org/) shows that, by just replacing the anonymous type for a `ValueTuple`, results in the method taking half the time, with no heap allocations.

![benchmark results](https://user-images.githubusercontent.com/534533/45879561-ecc9dc00-bd9c-11e8-90ba-af5ac7a87e0a.png)

A dependency is added for non-`netstandard2.0` projects. [System.ValueTuple](https://www.fuget.org/packages/System.ValueTuple) also supports `net461`, `net47`, `netstandard1.0` and `portable-net40+sl4+win8+wp8`.
