### PR TITLE
Improve performance of searching

### DIFF
--- a/src/SmartEnum.UnitTests/SmartEnumFromName.cs
+++ b/src/SmartEnum.UnitTests/SmartEnumFromName.cs
@@ -62,5 +62,11 @@ namespace SmartEnum.UnitTests
 
             Assert.Equal(expected, actual);
         }
+
+        [Fact]
+        public void ThrowsGivenDuplicate()
+        {
+            Assert.Throws<SmartEnumDuplicateException>(() => TestEnumDuplicate.FromName(TestEnumDuplicate.One.Name));
+        }    
     }
 }

--- a/src/SmartEnum.UnitTests/SmartEnumFromValue.cs
+++ b/src/SmartEnum.UnitTests/SmartEnumFromValue.cs
@@ -42,5 +42,11 @@ namespace SmartEnum.UnitTests
 
             Assert.Equal(defaultEnum, TestEnum.FromValue(-1, defaultEnum));
         }
+
+        [Fact]
+        public void ThrowsGivenDuplicate()
+        {
+            Assert.Throws<SmartEnumDuplicateException>(() => TestEnumDuplicate.FromValue(TestEnumDuplicate.One.Value));
+        }
     }
 }

--- a/src/SmartEnum.UnitTests/TestEnumDuplicate.cs
+++ b/src/SmartEnum.UnitTests/TestEnumDuplicate.cs
@@ -1,0 +1,14 @@
+using Ardalis.SmartEnum;
+
+namespace SmartEnum.UnitTests
+{
+    public class TestEnumDuplicate : SmartEnum<TestEnumDuplicate, int>
+    {
+        public static TestEnumDuplicate One = new TestEnumDuplicate(nameof(One), 1);
+        public static TestEnumDuplicate Two = new TestEnumDuplicate(nameof(One), 1);
+
+        protected TestEnumDuplicate(string name, int value) : base(name, value)
+        {
+        }
+    }
+}

--- a/src/SmartEnum/Exceptions/SmartEnumDuplicateException.cs
+++ b/src/SmartEnum/Exceptions/SmartEnumDuplicateException.cs
@@ -8,7 +8,7 @@ namespace SmartEnum.Exceptions
         public object Duplicate { get; }
 
         public SmartEnumDuplicateException(Type type, object duplicate) : 
-            base($"'{duplicate} is a duplicate in '{type.Name}'")
+            base($"'{duplicate}' is a duplicate in '{type.Name}'")
         {
             Type = type;
             Duplicate = duplicate;

--- a/src/SmartEnum/Exceptions/SmartEnumDuplicateException.cs
+++ b/src/SmartEnum/Exceptions/SmartEnumDuplicateException.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace SmartEnum.Exceptions
+{
+    public class SmartEnumDuplicateException : Exception
+    {
+        public SmartEnumDuplicateException() : base()
+        {
+        }
+
+        protected SmartEnumDuplicateException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context)
+        {
+        }
+
+        public SmartEnumDuplicateException(string message) : base(message)
+        {
+        }
+
+        public SmartEnumDuplicateException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/SmartEnum/Exceptions/SmartEnumDuplicateException.cs
+++ b/src/SmartEnum/Exceptions/SmartEnumDuplicateException.cs
@@ -4,20 +4,30 @@ namespace SmartEnum.Exceptions
 {
     public class SmartEnumDuplicateException : Exception
     {
-        public SmartEnumDuplicateException() : base()
+        public Type Type { get; }
+        public object Duplicate { get; }
+
+        public SmartEnumDuplicateException(Type type, object duplicate) : 
+            base($"'{duplicate} is a duplicate in '{type.Name}'")
         {
+            Type = type;
+            Duplicate = duplicate;
         }
 
         protected SmartEnumDuplicateException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context)
         {
         }
 
-        public SmartEnumDuplicateException(string message) : base(message)
+        public SmartEnumDuplicateException(Type type, object duplicate, string message) : base(message)
         {
+            Type = type;
+            Duplicate = duplicate;
         }
 
-        public SmartEnumDuplicateException(string message, Exception innerException) : base(message, innerException)
+        public SmartEnumDuplicateException(Type type, object duplicate, string message, Exception innerException) : base(message, innerException)
         {
+            Type = type;
+            Duplicate = duplicate;
         }
     }
 }

--- a/src/SmartEnum/SmartEnum.cs
+++ b/src/SmartEnum/SmartEnum.cs
@@ -21,14 +21,13 @@ namespace Ardalis.SmartEnum
         private static readonly Lazy<Dictionary<string, TEnum>> _fromName = 
             new Lazy<Dictionary<string, TEnum>>(() => ListAllOptions().ToDictionary(i => i.Name, StringComparer.OrdinalIgnoreCase));
 
-        private static List<TEnum> ListAllOptions()
+        private static IOrderedEnumerable<TEnum> ListAllOptions()
         {
             Type t = typeof(TEnum);
             return t.GetFields(BindingFlags.Public | BindingFlags.Static)
             .Where(p => t.IsAssignableFrom(p.FieldType))
             .Select(pi => (TEnum)pi.GetValue(null))
-            .OrderBy(p => p.Name)
-            .ToList();
+            .OrderBy(p => p.Name);
         }
 
         public static IReadOnlyCollection<TEnum> List => _fromValue.Value.Values;

--- a/src/SmartEnum/SmartEnum.cs
+++ b/src/SmartEnum/SmartEnum.cs
@@ -39,9 +39,9 @@ namespace Ardalis.SmartEnum
             foreach(var item in enums)
             {
                 var key = keySelector(item);
-                if(dictionary.TryGetValue(key, out var duplicate))
+                if(dictionary.ContainsKey(key))
                 {
-                    throw new SmartEnumDuplicateException();
+                    throw new SmartEnumDuplicateException(typeof(TKey), key);
                 }
                 dictionary.Add(key, item);
             }

--- a/src/SmartEnum/SmartEnum.cs
+++ b/src/SmartEnum/SmartEnum.cs
@@ -22,13 +22,12 @@ namespace Ardalis.SmartEnum
         private static readonly Lazy<Dictionary<string, TEnum>> _fromName = 
             new Lazy<Dictionary<string, TEnum>>(() => AsDictionary(ListAllOptions(), i => i.Name, StringComparer.OrdinalIgnoreCase));
 
-        private static IOrderedEnumerable<TEnum> ListAllOptions()
+        private static IEnumerable<TEnum> ListAllOptions()
         {
             Type t = typeof(TEnum);
             return t.GetFields(BindingFlags.Public | BindingFlags.Static)
             .Where(p => t.IsAssignableFrom(p.FieldType))
-            .Select(pi => (TEnum)pi.GetValue(null))
-            .OrderBy(p => p.Name);
+            .Select(pi => (TEnum)pi.GetValue(null));
         }
 
         private static Dictionary<TKey, TEnum> AsDictionary<TKey>(IEnumerable<TEnum> enums, 


### PR DESCRIPTION
The instances of the `SmartEnum` are lazy loaded into a `List<>` and `FirstOrDefault()` is used for searching. This is an O(n) operation and allocates a [List<>.Enumerator](https://github.com/dotnet/corefx/blob/v2.1.4/src/Common/src/CoreLib/System/Collections/Generic/List.cs#L1118), which is boxed, ending up in the heap.

With this PR, the `SmartEnum` are lazy loaded into two `Dictionary<,>` which allow O(1) operations when searching by name or value. No heap allocations.

The benchmark using [BenchmarkDotNet](https://benchmarkdotnet.org/) when searching for the first and the tenth elements, using both implementations, show the following results:

![screenshot at sep 21 16-43-22](https://user-images.githubusercontent.com/534533/45892334-b81b4c00-bdbf-11e8-8daa-85ef9e733951.png)

