### PR TITLE
Add AutoFixture support

### DIFF
--- a/src/SmartEnum.AutoFixture.UnitTests/SmartEnum.AutoFixture.UnitTests.csproj
+++ b/src/SmartEnum.AutoFixture.UnitTests/SmartEnum.AutoFixture.UnitTests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SmartEnum.AutoFixture\SmartEnum.AutoFixture.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/SmartEnum.AutoFixture.UnitTests/SmartEnumSpecimenBuilderCreate.cs
+++ b/src/SmartEnum.AutoFixture.UnitTests/SmartEnumSpecimenBuilderCreate.cs
@@ -1,0 +1,18 @@
+using System;
+using AutoFixture;
+using Xunit;
+
+namespace Ardalis.SmartEnum.AutoFixture.UnitTests
+{
+    public class SmartEnumSpecimenBuilderCreate
+    {
+        [Fact]
+        public void ReturnsEnumGivenNoExplicitPriorUse()
+        {
+            string expected = "One";
+            IFixture fixture =  new Fixture()
+                .Customize(new SmartEnumCustomization());
+            Assert.Equal(expected, fixture.Create<TestEnum>().Name);
+        }
+    }
+}

--- a/src/SmartEnum.AutoFixture.UnitTests/TestEnum.cs
+++ b/src/SmartEnum.AutoFixture.UnitTests/TestEnum.cs
@@ -1,0 +1,15 @@
+﻿using Ardalis.SmartEnum;
+
+namespace Ardalis.SmartEnum.AutoFixture.UnitTests
+{
+    public class TestEnum : SmartEnum<TestEnum, int>
+    {
+        public static TestEnum One = new TestEnum(nameof(One), 1);
+        public static TestEnum Two = new TestEnum(nameof(Two), 2);
+        public static TestEnum Three = new TestEnum(nameof(Three), 3);
+
+        protected TestEnum(string name, int value) : base(name, value)
+        {
+        }
+    }
+}

--- a/src/SmartEnum.AutoFixture/SmartEnum.AutoFixture.csproj
+++ b/src/SmartEnum.AutoFixture/SmartEnum.AutoFixture.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageId>Ardalis.SmartEnum.AutoFixture</PackageId>
+    <Title>Ardalis.SmartEnum.AutoFixture</Title>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <Authors>Steve Smith (@ardalis)</Authors>
+    <Company>Ardalis.com</Company>
+    <PackageProjectUrl>https://github.com/ardalis/SmartEnum</PackageProjectUrl>
+    <Description>Classes to help produce strongly typed smarter enums in .NET using AutoFixture.</Description>
+    <Summary>Classes to help produce strongly typed smarter enums in .NET using AutoFixture.</Summary>
+    <RepositoryUrl>https://github.com/ardalis/SmartEnum</RepositoryUrl>
+    <PackageTags>enum</PackageTags>
+    <PackageReleaseNotes></PackageReleaseNotes>
+    <Version>1.0.0</Version>
+    <AssemblyName>Ardalis.SmartEnum.AutoFixture</AssemblyName>
+    <PackageIconUrl>https://user-images.githubusercontent.com/782127/33497760-facf6550-d69c-11e7-94e4-b3856da259a9.png</PackageIconUrl>
+    <RootNamespace>Ardalis.SmartEnum.AutoFixture</RootNamespace>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SmartEnum\SmartEnum.csproj"/>
+  </ItemGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="AutoFixture" Version="4.5.0"/>
+  </ItemGroup>
+</Project>

--- a/src/SmartEnum.AutoFixture/SmartEnumCustomization.cs
+++ b/src/SmartEnum.AutoFixture/SmartEnumCustomization.cs
@@ -1,0 +1,13 @@
+using System;
+using AutoFixture;
+
+namespace Ardalis.SmartEnum.AutoFixture
+{
+    public class SmartEnumCustomization : ICustomization
+    {
+        public void Customize(IFixture fixture)
+        {
+            fixture.Customizations.Add(new SmartEnumSpecimenBuilder());
+        }
+    }
+}

--- a/src/SmartEnum.AutoFixture/SmartEnumSpecimenBuilder.cs
+++ b/src/SmartEnum.AutoFixture/SmartEnumSpecimenBuilder.cs
@@ -1,0 +1,22 @@
+using System;
+using AutoFixture.Kernel;
+    
+namespace Ardalis.SmartEnum.AutoFixture
+{
+    public class SmartEnumSpecimenBuilder :
+        ISpecimenBuilder
+    {
+        public object Create(object request, ISpecimenContext context)
+        {
+            if(request is Type type && Utils.IsSmartEnum(type, out var enums))
+            {
+                // return first 
+                var enumerator = enums.GetEnumerator();
+                if(enumerator.MoveNext())
+                    return enumerator.Current;
+            }
+
+            return new NoSpecimen();
+        }
+    }
+}

--- a/src/SmartEnum.AutoFixture/Utils.cs
+++ b/src/SmartEnum.AutoFixture/Utils.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections;
+using System.Reflection;
+
+namespace Ardalis.SmartEnum.AutoFixture
+{
+    internal static class Utils
+    {
+        public static bool IsSmartEnum(Type type, out IEnumerable enums)
+        {
+            while (type != null)
+            {
+                if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(SmartEnum<,>))
+                {
+                    var listPropertyInfo = type.GetProperty("List", BindingFlags.Public | BindingFlags.Static);
+                    enums = (IEnumerable)listPropertyInfo.GetValue(type, null);
+                    return true;
+                }
+                type = type.BaseType;
+            }
+
+            enums = null;
+            return false;
+        }
+    }
+}

--- a/src/SmartEnum.sln
+++ b/src/SmartEnum.sln
@@ -7,6 +7,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SmartEnum", "SmartEnum\Smar
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SmartEnum.UnitTests", "SmartEnum.UnitTests\SmartEnum.UnitTests.csproj", "{7EC129B9-8A9B-469E-A160-8C351161F097}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SmartEnum.AutoFixture", "SmartEnum.AutoFixture\SmartEnum.AutoFixture.csproj", "{97908BA0-B656-47CE-81E6-3011734082BA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SmartEnum.AutoFixture.UnitTests", "SmartEnum.AutoFixture.UnitTests\SmartEnum.AutoFixture.UnitTests.csproj", "{790CC856-58C4-47F3-8561-00B9D912B1D1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +25,14 @@ Global
 		{7EC129B9-8A9B-469E-A160-8C351161F097}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7EC129B9-8A9B-469E-A160-8C351161F097}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7EC129B9-8A9B-469E-A160-8C351161F097}.Release|Any CPU.Build.0 = Release|Any CPU
+		{97908BA0-B656-47CE-81E6-3011734082BA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{97908BA0-B656-47CE-81E6-3011734082BA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{97908BA0-B656-47CE-81E6-3011734082BA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{97908BA0-B656-47CE-81E6-3011734082BA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{790CC856-58C4-47F3-8561-00B9D912B1D1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{790CC856-58C4-47F3-8561-00B9D912B1D1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{790CC856-58C4-47F3-8561-00B9D912B1D1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{790CC856-58C4-47F3-8561-00B9D912B1D1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
AutoFixture is a library the allows automatic creation of object instances for unit testing. 

SmartEnums should not be created. They should be referenced from existing static instances. AutoFixture does not know how to deal with this. A ISpecimenBuilder has to be created to implement a compatible behavior.

This PR adds:
- A project that creates a NuGet package that depends on SmartEnum and AutoFixture containing:
  - An implementation of ISpecimenBuilder that returns a reference to the first enum of a given SmartEnum.
  - An implementation of ICustomization that adds the custom ISpecimenBuilder to the fixture.
- A project that unit tests this new features