### PR TITLE
Adds WCF Support

### DIFF
--- a/src/SmartEnum.UnitTests/Wcf/SmartEnumWcfSerialization.cs
+++ b/src/SmartEnum.UnitTests/Wcf/SmartEnumWcfSerialization.cs
@@ -15,9 +15,11 @@ namespace SmartEnum.UnitTests.Wcf
         public void SurvivesSerializationRoundTrip()
         {
             var result = WcfTestHelper.DataContractSerializationRoundTrip(TestEnum.One);
+            var resultJson = WcfTestHelper.DataContractJsonSerializationRoundTrip(TestEnum.One);
 
 
             Assert.Equal(TestEnum.One, result);
+            Assert.Equal(TestEnum.One, resultJson);
         }
 
         /// <summary>
@@ -33,9 +35,11 @@ namespace SmartEnum.UnitTests.Wcf
             var expected = new TestObjectWithTestEnumProperty { Test = TestWcfEnum.One };
             
             var result = WcfTestHelper.DataContractSerializationRoundTrip(expected);
+            var resultJson = WcfTestHelper.DataContractJsonSerializationRoundTrip(expected);
 
 
             Assert.Equal(expected.Test, result.Test);
+            Assert.Equal(expected.Test, resultJson.Test);
         }
 
         /// <summary>
@@ -50,9 +54,11 @@ namespace SmartEnum.UnitTests.Wcf
             var expected = new TestObjectWithSmartEnumProperty { Test = TestWcfEnum.One };
             
             var result = WcfTestHelper.DataContractSerializationRoundTrip(expected);
+            var resultJson = WcfTestHelper.DataContractJsonSerializationRoundTrip(expected);
 
 
             Assert.Equal(expected.Test, result.Test);
+            Assert.Equal(expected.Test, resultJson.Test);
         }
 
         /// <summary>
@@ -71,9 +77,11 @@ namespace SmartEnum.UnitTests.Wcf
             var expected = new TestObjectWithSmartEnumProperty { Test = TestWcfEnumSubClass.Four };
             
             var result = WcfTestHelper.DataContractSerializationRoundTrip(expected);
+            var resultJson = WcfTestHelper.DataContractJsonSerializationRoundTrip(expected);
 
 
             Assert.Equal(expected.Test, result.Test);
+            Assert.Equal(expected.Test, resultJson.Test);
         }
     }
 }

--- a/src/SmartEnum.UnitTests/Wcf/SmartEnumWcfSerialization.cs
+++ b/src/SmartEnum.UnitTests/Wcf/SmartEnumWcfSerialization.cs
@@ -1,0 +1,53 @@
+﻿using Xunit;
+
+namespace SmartEnum.UnitTests.Wcf
+{
+
+    public class SmartEnumWcfSerialization
+    {
+        [Fact]
+        public void SurvivesSerializationRoundTrip()
+        {
+            var result = WcfTestHelper.DataContractSerializationRoundTrip(TestWcfEnum.One);
+
+
+            Assert.Equal(TestWcfEnum.One, result);
+        }
+
+        [Fact]
+        public void SurvivesSerializationRoundTripAsPartOfAnotherObject()
+        {
+            var expected = new TestObjectWithTestEnumProperty { Test = TestWcfEnum.One };
+            
+            var result = WcfTestHelper.DataContractSerializationRoundTrip(expected);
+
+
+            Assert.Equal(expected.Test, result.Test);
+        }
+
+        [Fact]
+        public void SurvivesSerializationRoundTripAsPartOfAnotherObjectAsADerivedType()
+        {
+            var expected = new TestObjectWithSmartEnumProperty { Test = TestWcfEnum.One };
+            
+            var result = WcfTestHelper.DataContractSerializationRoundTrip(expected);
+
+
+            Assert.Equal(expected.Test, result.Test);
+        }
+
+        [Fact]
+        public void SurvivesSerializationRoundTripAsPartOfAnotherObjectAsADerivedTypeOfADerivedType()
+        {
+            var expectedUsingInheritedValue = new TestObjectWithSmartEnumProperty { Test = TestWcfEnumSubClass.One };
+            var expectedUsingNewValue = new TestObjectWithSmartEnumProperty { Test = TestWcfEnumSubClass.Four };
+            
+            var resultUsingInheritedValue = WcfTestHelper.DataContractSerializationRoundTrip(expectedUsingInheritedValue);
+            var resultUsingNewValue = WcfTestHelper.DataContractSerializationRoundTrip(expectedUsingNewValue);
+
+
+            Assert.Equal(expectedUsingInheritedValue.Test, resultUsingInheritedValue.Test);
+            Assert.Equal(expectedUsingNewValue.Test, resultUsingNewValue.Test);
+        }
+    }
+}

--- a/src/SmartEnum.UnitTests/Wcf/SmartEnumWcfSerialization.cs
+++ b/src/SmartEnum.UnitTests/Wcf/SmartEnumWcfSerialization.cs
@@ -5,15 +5,28 @@ namespace SmartEnum.UnitTests.Wcf
 
     public class SmartEnumWcfSerialization
     {
+        /// <summary>
+        /// Basic test to prove that a class that is derived from <see cref="SmartEnum"/>
+        /// can go through the serialization process directly. This test fails
+        /// if <see cref="SmartEnum"/> is not marked with the <see cref="DataContract"/>
+        ///  attribute and the appropriate <see cref="DataMember"/> attributes.
+        /// </summary>
         [Fact]
         public void SurvivesSerializationRoundTrip()
         {
-            var result = WcfTestHelper.DataContractSerializationRoundTrip(TestWcfEnum.One);
+            var result = WcfTestHelper.DataContractSerializationRoundTrip(TestEnum.One);
 
 
-            Assert.Equal(TestWcfEnum.One, result);
+            Assert.Equal(TestEnum.One, result);
         }
 
+        /// <summary>
+        /// Proves that a class that contains a property with a type derived from
+        /// <see cref="SmartEnum"/> can go through the serialization process. This
+        /// test fails if  <see cref="SmartEnum"/> is not marked with the
+        /// <see cref="DataContract"/> attribute and the appropriate
+        /// <see cref="DataMember"/> attributes.
+        /// </summary>
         [Fact]
         public void SurvivesSerializationRoundTripAsPartOfAnotherObject()
         {
@@ -25,6 +38,12 @@ namespace SmartEnum.UnitTests.Wcf
             Assert.Equal(expected.Test, result.Test);
         }
 
+        /// <summary>
+        /// Proves that a class that contains a <see cref="SmartEnum"/> property
+        /// can go through the serialization process when the property is set with
+        /// a value that is a derived type of <see cref="SmartEnum"/>. This test
+        /// fails if <see cref="SmartEnum"/> does not specify its known types.
+        /// </summary>
         [Fact]
         public void SurvivesSerializationRoundTripAsPartOfAnotherObjectAsADerivedType()
         {
@@ -36,18 +55,25 @@ namespace SmartEnum.UnitTests.Wcf
             Assert.Equal(expected.Test, result.Test);
         }
 
+        /// <summary>
+        /// Proves that a class that contains a <see cref="SmartEnum"/> property
+        /// can go through the serialization process when the property is set with
+        /// a value that is a derived type of a derived type of <see cref="SmartEnum"/>.
+        /// This test fails if <see cref="SmartEnum"/> and its derived type do not
+        /// specify known types.
+        ///
+        /// NOTE: This test, while not specifically for the base <see cref="SmartEnum"/>
+        /// functionality, is included as an example to demonstrate expected typical usage.
+        /// </summary>
         [Fact]
         public void SurvivesSerializationRoundTripAsPartOfAnotherObjectAsADerivedTypeOfADerivedType()
         {
-            var expectedUsingInheritedValue = new TestObjectWithSmartEnumProperty { Test = TestWcfEnumSubClass.One };
-            var expectedUsingNewValue = new TestObjectWithSmartEnumProperty { Test = TestWcfEnumSubClass.Four };
+            var expected = new TestObjectWithSmartEnumProperty { Test = TestWcfEnumSubClass.Four };
             
-            var resultUsingInheritedValue = WcfTestHelper.DataContractSerializationRoundTrip(expectedUsingInheritedValue);
-            var resultUsingNewValue = WcfTestHelper.DataContractSerializationRoundTrip(expectedUsingNewValue);
+            var result = WcfTestHelper.DataContractSerializationRoundTrip(expected);
 
 
-            Assert.Equal(expectedUsingInheritedValue.Test, resultUsingInheritedValue.Test);
-            Assert.Equal(expectedUsingNewValue.Test, resultUsingNewValue.Test);
+            Assert.Equal(expected.Test, result.Test);
         }
     }
 }

--- a/src/SmartEnum.UnitTests/Wcf/TestObjectWithSmartEnumProperty.cs
+++ b/src/SmartEnum.UnitTests/Wcf/TestObjectWithSmartEnumProperty.cs
@@ -1,0 +1,12 @@
+﻿using System.Runtime.Serialization;
+using Ardalis.SmartEnum;
+
+namespace SmartEnum.UnitTests.Wcf
+{
+    [DataContract]
+    public class TestObjectWithSmartEnumProperty
+    {
+        [DataMember]
+        public SmartEnum<TestWcfEnum, int> Test { get; set; }
+    }
+}

--- a/src/SmartEnum.UnitTests/Wcf/TestObjectWithTestEnumProperty.cs
+++ b/src/SmartEnum.UnitTests/Wcf/TestObjectWithTestEnumProperty.cs
@@ -1,7 +1,6 @@
 ﻿using System.Runtime.Serialization;
-using SmartEnum.UnitTests.Wcf;
 
-namespace SmartEnum.UnitTests
+namespace SmartEnum.UnitTests.Wcf
 {
     [DataContract]
     public class TestObjectWithTestEnumProperty

--- a/src/SmartEnum.UnitTests/Wcf/TestObjectWithTestEnumProperty.cs
+++ b/src/SmartEnum.UnitTests/Wcf/TestObjectWithTestEnumProperty.cs
@@ -1,0 +1,12 @@
+﻿using System.Runtime.Serialization;
+using SmartEnum.UnitTests.Wcf;
+
+namespace SmartEnum.UnitTests
+{
+    [DataContract]
+    public class TestObjectWithTestEnumProperty
+    {
+        [DataMember]
+        public TestWcfEnum Test { get; set; }
+    }
+}

--- a/src/SmartEnum.UnitTests/Wcf/TestWcfEnum.cs
+++ b/src/SmartEnum.UnitTests/Wcf/TestWcfEnum.cs
@@ -25,15 +25,19 @@ namespace SmartEnum.UnitTests.Wcf
 
         private static IEnumerable<Type> _knownTypes;
 
+        /// <summary>
+        /// Finds all subclasses of this type via reflection so they can be
+        /// known to the serializer.
+        /// </summary>
+        /// <returns></returns>
         private static IEnumerable<Type> GetKnownTypes()
         {
             // The list has already been created, no need to do it again.
             if (_knownTypes != null) return _knownTypes;
 
-            var assemblies = AppDomain.CurrentDomain.GetAssemblies();
-            var types = assemblies.SelectMany(assembly => assembly.GetTypes());
-
-            _knownTypes = types.Where(type => type.IsSubclassOf(typeof(TestWcfEnum)));
+            _knownTypes = AppDomain.CurrentDomain.GetAssemblies()
+                            .SelectMany(assembly => assembly.GetTypes())
+                            .Where(type => type.IsSubclassOf(typeof(TestWcfEnum)));
 
             return _knownTypes;
         }

--- a/src/SmartEnum.UnitTests/Wcf/TestWcfEnum.cs
+++ b/src/SmartEnum.UnitTests/Wcf/TestWcfEnum.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using Ardalis.SmartEnum;
+
+namespace SmartEnum.UnitTests.Wcf
+{
+    [DataContract]
+    [KnownType(nameof(GetKnownTypes))]
+    public class TestWcfEnum : SmartEnum<TestWcfEnum, int>
+    {
+        public static TestWcfEnum One = new TestWcfEnum(nameof(One), 1);
+        public static TestWcfEnum Two = new TestWcfEnum(nameof(Two), 2);
+        public static TestWcfEnum Three = new TestWcfEnum(nameof(Three), 3);
+
+        protected TestWcfEnum(string name, int value) : base(name, value)
+        {
+        }
+
+        protected TestWcfEnum() : base()
+        {
+            // required for EF
+        }
+
+        private static IEnumerable<Type> _knownTypes;
+
+        private static IEnumerable<Type> GetKnownTypes()
+        {
+            // The list has already been created, no need to do it again.
+            if (_knownTypes != null) return _knownTypes;
+
+            var assemblies = AppDomain.CurrentDomain.GetAssemblies();
+            var types = assemblies.SelectMany(assembly => assembly.GetTypes());
+
+            _knownTypes = types.Where(type => type.IsSubclassOf(typeof(TestWcfEnum)));
+
+            return _knownTypes;
+        }
+    }
+}

--- a/src/SmartEnum.UnitTests/Wcf/TestWcfEnumSubClass.cs
+++ b/src/SmartEnum.UnitTests/Wcf/TestWcfEnumSubClass.cs
@@ -1,0 +1,18 @@
+﻿namespace SmartEnum.UnitTests.Wcf
+{
+    public class TestWcfEnumSubClass : TestWcfEnum
+    {
+        public static TestWcfEnumSubClass Four = new TestWcfEnumSubClass(nameof(Four), 1);
+        public static TestWcfEnumSubClass Five = new TestWcfEnumSubClass(nameof(Five), 2);
+        public static TestWcfEnumSubClass Six = new TestWcfEnumSubClass(nameof(Six), 3);
+
+        protected TestWcfEnumSubClass(string name, int value) : base(name, value)
+        {
+        }
+
+        private TestWcfEnumSubClass() :base()
+        {
+            // required for EF
+        }
+    }
+}

--- a/src/SmartEnum.UnitTests/Wcf/WcfTestHelper.cs
+++ b/src/SmartEnum.UnitTests/Wcf/WcfTestHelper.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Json;
+
+namespace SmartEnum.UnitTests
+{
+    /// <summary>
+    /// A helper class to aid in testing the WCF Serialization of an object.
+    /// Source: https://stackoverflow.com/a/974035 with the addition of adding
+    /// support for JSON by adding methods using the <see cref="DataContractJsonSerializer"/>
+    /// instead of the regular <see cref="DataContractSerializer"/>.
+    /// </summary>
+    public static class WcfTestHelper
+    {
+        /// <summary>
+        /// Uses a <see cref="DataContractSerializer"/> to serialise the object into
+        /// memory, then deserialise it again and return the result.  This is useful
+        /// in tests to validate that your object is serialisable, and that it
+        /// serialises correctly.
+        /// </summary>
+        public static T DataContractSerializationRoundTrip<T>(T obj)
+        {
+            return DataContractSerializationRoundTrip(obj, null);
+        }
+
+        /// <summary>
+        /// Uses a <see cref="DataContractSerializer"/> to serialise the object into
+        /// memory, then deserialise it again and return the result.  This is useful
+        /// in tests to validate that your object is serialisable, and that it
+        /// serialises correctly.
+        /// </summary>
+        public static T DataContractSerializationRoundTrip<T>(T obj,
+            IEnumerable<Type> knownTypes)
+        {
+            var serializer = new DataContractSerializer(obj.GetType(), knownTypes);
+            var memoryStream = new MemoryStream();
+            serializer.WriteObject(memoryStream, obj);
+            memoryStream.Position = 0;
+            obj = (T)serializer.ReadObject(memoryStream);
+            return obj;
+        }
+
+        /// <summary>
+        /// Uses a <see cref="DataContractJsonSerializer"/> to serialise the object into
+        /// memory, then deserialise it again and return the result.  This is useful
+        /// in tests to validate that your object is serialisable, and that it
+        /// serialises correctly.
+        /// </summary>
+        public static T DataContractJsonSerializationRoundTrip<T>(T obj)
+        {
+            return DataContractJsonSerializationRoundTrip(obj, null);
+        }
+
+        /// <summary>
+        /// Uses a <see cref="DataContractJsonSerializer"/> to serialise the object into
+        /// memory, then deserialise it again and return the result.  This is useful
+        /// in tests to validate that your object is serialisable, and that it
+        /// serialises correctly.
+        /// </summary>
+        public static T DataContractJsonSerializationRoundTrip<T>(T obj,
+            IEnumerable<Type> knownTypes)
+        {
+            var serializer = new DataContractJsonSerializer(obj.GetType(), knownTypes);
+            var memoryStream = new MemoryStream();
+            serializer.WriteObject(memoryStream, obj);
+            memoryStream.Position = 0;
+            obj = (T)serializer.ReadObject(memoryStream);
+            return obj;
+        }
+    }
+}

--- a/src/SmartEnum/SmartEnum.cs
+++ b/src/SmartEnum/SmartEnum.cs
@@ -13,8 +13,12 @@ namespace Ardalis.SmartEnum
     /// TEnum is the type that is inheriting from this class.
     /// TValue is the type of the enum value, typically int.
     /// </summary>
-    /// <remarks></remarks>
+    /// <remarks>
+    /// Known Types are reported for serialization for direct derived types only.
+    /// Those types must report their own list of known types.
+    /// </remarks>
     [DataContract]
+    [KnownType(nameof(GetKnownTypes))]
     public abstract class SmartEnum<TEnum, TValue> : IEquatable<SmartEnum<TEnum, TValue>>
         where TEnum : SmartEnum<TEnum, TValue>
     {
@@ -132,5 +136,7 @@ namespace Ardalis.SmartEnum
 
         public static implicit operator TValue(SmartEnum<TEnum, TValue> smartEnum) => smartEnum.Value;
         public static explicit operator SmartEnum<TEnum, TValue>(TValue value) => FromValue(value);
+
+        private static IEnumerable<Type> GetKnownTypes() => new List<Type> { typeof(TEnum) };
     }
 }

--- a/src/SmartEnum/SmartEnum.cs
+++ b/src/SmartEnum/SmartEnum.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.Serialization;
 
 namespace Ardalis.SmartEnum
 {
@@ -13,6 +14,7 @@ namespace Ardalis.SmartEnum
     /// TValue is the type of the enum value, typically int.
     /// </summary>
     /// <remarks></remarks>
+    [DataContract]
     public abstract class SmartEnum<TEnum, TValue> : IEquatable<SmartEnum<TEnum, TValue>>
         where TEnum : SmartEnum<TEnum, TValue>
     {
@@ -30,7 +32,9 @@ namespace Ardalis.SmartEnum
 
         public static List<TEnum> List => _list.Value;
 
-        public string Name { get; }
+        [DataMember]
+        public string Name { get; protected set;  }
+        [DataMember]
         public TValue Value { get; protected set; }
 
         protected SmartEnum(string name, TValue value)


### PR DESCRIPTION
Addresses the request in #23 to make `SmartEnum` data contract friendly by doing the following:
- Adds the `[DataContract]` and `[DataMember]` attributes as necessary
- Adds method to report the deriving type via the `[KnownType]` attribute the it can be properly serialized as a `SmartEnum`

Tests were added for several specific use cases with each test case documented.

 