### PR TITLE
Change Equals() to only compare Value. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ bld/
 
 # Visual Studio 2015 cache/options directory
 .vs/
+# Visual Studio Code cache/options directory
+.vscode/
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 
@@ -286,3 +288,6 @@ __pycache__/
 *.btm.cs
 *.odx.cs
 *.xsd.cs
+
+# BenchmarkDotNet
+BenchmarkDotNet.Artifacts/

--- a/src/SmartEnum.Benchmarks/EqualsBenchmarks.cs
+++ b/src/SmartEnum.Benchmarks/EqualsBenchmarks.cs
@@ -1,0 +1,49 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Ardalis.SmartEnum.Benchmarks
+{
+    [MemoryDiagnoser]
+    public class EqualsBenchmarks
+    {
+        public class TestEnum : SmartEnum<TestEnum, int>
+        {
+            public static TestEnum One = new TestEnum(nameof(One), 1);
+            public static TestEnum Two = new TestEnum(nameof(Two), 2);
+
+            protected TestEnum(string name, int value) : base(name, value)
+            {
+            }
+        }
+
+        public class TestEnum2 : SmartEnum<TestEnum2, int>
+        {
+            public static TestEnum2 One = new TestEnum2(nameof(One), 1);
+            public static TestEnum2 Two = new TestEnum2(nameof(Two), 2);
+
+            protected TestEnum2(string name, int value) : base(name, value)
+            {
+            }
+        }
+
+        [Benchmark]
+        public new int GetHashCode() => TestEnum.One.GetHashCode();
+
+        [Benchmark]
+        public bool Equals_Null() => TestEnum.One.Equals((TestEnum)null);    
+
+        [Benchmark]
+        public bool Equals_ReferenceEquals() => TestEnum.One.Equals(TestEnum.One);
+
+        [Benchmark]
+        public bool Equals_DifferentValue() => TestEnum.One.Equals(TestEnum.Two);   
+
+        [Benchmark]
+        public bool Equals_DifferentType() => TestEnum.One.Equals(TestEnum2.One);    
+
+        [Benchmark]
+        public bool EqualOperator() => TestEnum.One == TestEnum.Two;
+
+        [Benchmark]
+        public bool NotEqualOperator() => TestEnum.One != TestEnum.Two;    
+    }
+}

--- a/src/SmartEnum.Benchmarks/Program.cs
+++ b/src/SmartEnum.Benchmarks/Program.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Running;
+
+namespace Ardalis.SmartEnum.Benchmarks
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            var switcher = new BenchmarkSwitcher(new[] {
+                    typeof(EqualsBenchmarks),
+                    typeof(SearchBenchmarks),
+                });
+            switcher.Run(args);        }
+    }
+}

--- a/src/SmartEnum.Benchmarks/SearchBenchmarks.cs
+++ b/src/SmartEnum.Benchmarks/SearchBenchmarks.cs
@@ -1,0 +1,158 @@
+using BenchmarkDotNet.Attributes;
+using SmartEnum.Exceptions;
+
+namespace Ardalis.SmartEnum.Benchmarks
+{
+
+    [MemoryDiagnoser]
+    public class SearchBenchmarks
+    {
+        public class TestEnum : SmartEnum<TestEnum, int>
+        {
+            public static TestEnum One = new TestEnum(nameof(One), 1);
+            public static TestEnum Two = new TestEnum(nameof(Two), 2);
+            public static TestEnum Three = new TestEnum(nameof(Three), 3);
+            public static TestEnum Four = new TestEnum(nameof(Four), 4);
+            public static TestEnum Five = new TestEnum(nameof(Five), 5);
+            public static TestEnum Six = new TestEnum(nameof(Six), 6);
+            public static TestEnum Seven = new TestEnum(nameof(Seven), 7);
+            public static TestEnum Eight = new TestEnum(nameof(Eight), 8);
+            public static TestEnum Nine = new TestEnum(nameof(Nine), 9);
+            public static TestEnum Ten = new TestEnum(nameof(Ten), 10);
+
+            protected TestEnum(string name, int value) : base(name, value)
+            {
+            }
+        }
+
+        [Benchmark]
+        public TestEnum FromValue_1() => TestEnum.FromValue(1);
+
+        [Benchmark]
+        public TestEnum FromValue_10() => TestEnum.FromValue(10);
+
+        [Benchmark]
+        public TestEnum FromValue_Invalid()
+        {
+            try
+            {
+                return TestEnum.FromValue(1_000);
+            }
+            catch(SmartEnumNotFoundException)
+            {
+                return null;
+            }
+        }
+
+        [Benchmark]
+        public TestEnum TryFromValue_1()
+        {
+            if(TestEnum.TryFromValue(1, out var result))
+                return result;
+            return null;
+        }
+
+        [Benchmark]
+        public TestEnum TryFromValue_10()
+        {
+            if(TestEnum.TryFromValue(10, out var result))
+                return result;
+            return null;
+        }
+
+        [Benchmark]
+        public TestEnum TryFromValue_Invalid()
+        {
+            if(TestEnum.TryFromValue(1_000, out var result))
+                return result;
+            return null;
+        }
+
+        [Benchmark]
+        public TestEnum FromName_One() => TestEnum.FromName("One", false);
+
+        [Benchmark]
+        public TestEnum FromName_Ten() => TestEnum.FromName("Ten", false);
+
+        [Benchmark]
+        public TestEnum FromName_Invalid()
+        {
+            try
+            {
+                return TestEnum.FromName("Invalid", false);
+            }
+            catch(SmartEnumNotFoundException)
+            {
+                return null;
+            }
+        }
+        
+        [Benchmark]
+        public TestEnum FromName_one_IgnoreCase() => TestEnum.FromName("one", true);
+
+        [Benchmark]
+        public TestEnum FromName_ten_IgnoreCase() => TestEnum.FromName("ten", true);     
+
+
+        [Benchmark]
+        public TestEnum FromName_Invalid_IgnoreCase()
+        {
+            try
+            {
+                return TestEnum.FromName("Invalid", true);
+            }
+            catch(SmartEnumNotFoundException)
+            {
+                return null;
+            }
+        }        
+        
+        [Benchmark]
+        public TestEnum TryFromName_One()
+        {
+            if(TestEnum.TryFromName("One", false, out var result))
+                return result;
+            return null;
+        }
+
+        [Benchmark]
+        public TestEnum TryFromName_Ten()
+        {
+            if(TestEnum.TryFromName("Ten", false, out var result))
+                return result;
+            return null;
+        }
+        
+        [Benchmark]
+        public TestEnum TryFromName_Invalid()
+        {
+            if(TestEnum.TryFromName("Invalid", false, out var result))
+                return result;
+            return null;
+        }
+
+        [Benchmark]
+        public TestEnum TryFromName_one_IgnoreCase()
+        {
+            if(TestEnum.TryFromName("one", true, out var result))
+                return result;
+            return null;
+        }
+
+        [Benchmark]
+        public TestEnum TryFromName_ten_IgnoreCase()
+        {
+            if(TestEnum.TryFromName("ten", true, out var result))
+                return result;
+            return null;
+        }
+        
+        [Benchmark]
+        public TestEnum TryFromName_Invalid_IgnoreCase()
+        {
+            if(TestEnum.TryFromName("Invalid", true, out var result))
+                return result;
+            return null;
+        }    
+    }
+}

--- a/src/SmartEnum.Benchmarks/SmartEnum.Benchmarks.csproj
+++ b/src/SmartEnum.Benchmarks/SmartEnum.Benchmarks.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.11.1"/>
+    <ProjectReference Include="..\SmartEnum\SmartEnum.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/SmartEnum.UnitTests/SmartEnumEquals.cs
+++ b/src/SmartEnum.UnitTests/SmartEnumEquals.cs
@@ -1,0 +1,73 @@
+using SmartEnum.Exceptions;
+using System;
+using Xunit;
+
+namespace SmartEnum.UnitTests
+{
+    public class SmartEnumEquals
+    {
+        private class TestEnum2 : Ardalis.SmartEnum.SmartEnum<TestEnum2, int>
+        {
+            public static TestEnum2 One = new TestEnum2(nameof(One), 1);
+            protected TestEnum2(string name, int value) : base(name, value)
+            {
+            }
+        }
+
+        public static TheoryData<TestEnum, object, bool> EqualsObjectData =>
+            new TheoryData<TestEnum, object, bool> 
+            {
+                { TestEnum.One, null, false },
+                { TestEnum.One, TestEnum.One, true },
+                { TestEnum.One, TestEnum2.One, false },
+                { TestEnum.One, TestEnum.Two, false },
+            };
+
+        [Theory]
+        [MemberData(nameof(EqualsObjectData))]
+        public void EqualsObjectReturnsExpected(TestEnum left, object right, bool expected)
+        {
+            Assert.Equal(expected, left.Equals(right));
+        }
+
+        public static TheoryData<TestEnum, TestEnum, bool> EqualsSmartEnumData =>
+            new TheoryData<TestEnum, TestEnum, bool> 
+            {
+                { TestEnum.One, null, false },
+                { TestEnum.One, TestEnum.One, true },
+                { TestEnum.One, TestEnum.Two, false },
+            };
+
+        [Theory]
+        [MemberData(nameof(EqualsSmartEnumData))]
+        public void EqualsSmartEnumReturnsExpected(TestEnum left, object right, bool expected)
+        {
+            Assert.Equal(expected, left.Equals(right));
+        }
+
+        public static TheoryData<TestEnum, object, bool> EqualOperatorData =>
+            new TheoryData<TestEnum, object, bool> 
+            {
+                { null, null, true },
+                { null, TestEnum.One, false },
+                { TestEnum.One, null, false },
+                { TestEnum.One, TestEnum.One, true },
+                { TestEnum.One, TestEnum2.One, false },
+                { TestEnum.One, TestEnum.Two, false },
+            };
+
+        [Theory]
+        [MemberData(nameof(EqualOperatorData))]
+        public void EqualOperatorReturnsExpected(TestEnum left, object right, bool expected)
+        {
+            Assert.Equal(expected, left == right);
+        }
+
+        [Theory]
+        [MemberData(nameof(EqualOperatorData))]
+        public void NotEqualOperatorReturnsExpected(TestEnum left, object right, bool expected)
+        {
+            Assert.Equal(!expected, left != right);
+        }
+    }
+} 

--- a/src/SmartEnum/SmartEnum.cs
+++ b/src/SmartEnum/SmartEnum.cs
@@ -7,6 +7,12 @@ using System.Reflection;
 
 namespace Ardalis.SmartEnum
 {
+    /// <summary>
+    /// A base type to use for creating smart enums in .NET.
+    /// </summary>
+    /// <typeparam name="TEnum">The type that is inheriting from this class.</typeparam>
+    /// <typeparam name="TValue">The type of the enum value, typically <see cref="System.Int32"/>.</typeparam>
+    /// <remarks></remarks>
     public abstract class SmartEnum<TEnum, TValue> : IEquatable<SmartEnum<TEnum, TValue>>
         where TEnum : SmartEnum<TEnum, TValue>
     {

--- a/src/SmartEnum/SmartEnum.csproj
+++ b/src/SmartEnum/SmartEnum.csproj
@@ -20,7 +20,7 @@
     <AssemblyVersion>1.0.5.0</AssemblyVersion>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard1.1|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'">
     <DefineConstants>TRACE;DEBUG</DefineConstants>
   </PropertyGroup>
 


### PR DESCRIPTION
This is a follow up on #30 that suggests changing `Equals()` and `GetHashCode()` to only compare `Value`. Advantages are explained in the issue description.

This PR also contains the following:
- Adds `TryFromName()` and `TryFromValue()` methods. These allow searching without exceptions thrown, improving considerably performance.
- Adds a `ignoreCase` parameter to `FromName()` and `TryFromName()`. The defaut value is `true`to not break previous contract but, this is not the usual default value for this option and has considerably worst performance.
- Adds unit test for equals operations.
- Adds benchmarking project with option to benchmark equals or search operations.

### Equals Benchmarks

<img width="656" alt="screenshot at sep 30 21-18-34" src="https://user-images.githubusercontent.com/534533/46262484-e0aaf080-c4f9-11e8-9576-5750f4978cb7.png">

The performance much better than for current master branch or even with changes proposed in #26 .

### Search Benchmarks

<img width="709" alt="screenshot at sep 30 21-27-07" src="https://user-images.githubusercontent.com/534533/46262526-6cbd1800-c4fa-11e8-9f4d-d51360fe7d17.png">

The use os dictionaries make all search operations to have O(1) complexity. The use of exception is considerably slower than `TryFromName()` and `TryFromValue()` that are actually faster when value is invalid than when valid. Case sensitive searching is faster than when casing ignored.

