### PR TITLE
WIP: Add support for WCF 

### DIFF
--- a/src/SmartEnum.Serialization.UnitTests/SmartEnum.Serialization.UnitTests.csproj
+++ b/src/SmartEnum.Serialization.UnitTests/SmartEnum.Serialization.UnitTests.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <LangVersion>7.3</LangVersion>
+    <Features>strict</Features>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.analyzers" Version="0.10.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="FluentAssertions" Version="5.5.3" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SmartEnum.Serialization\SmartEnum.Serialization.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/SmartEnum.Serialization/SmartEnum.Serialization.csproj
+++ b/src/SmartEnum.Serialization/SmartEnum.Serialization.csproj
@@ -1,0 +1,31 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <PackageId>Ardalis.SmartEnum.Serialization</PackageId>
+    <Title>Ardalis.SmartEnum.Serialization</Title>
+    <Company>Ardalis.com</Company>
+    <Summary>System.Runtime.Serialization support for Ardalis.SmartEnum.</Summary>
+    <PackageTags>enum;smartenum;netstandard2.0;json;json.net;converter</PackageTags>
+    <PackageReleaseNotes></PackageReleaseNotes>
+    <Version>1.0.0</Version>
+    <AssemblyName>Ardalis.SmartEnum.Serialization</AssemblyName>
+    <RootNamespace>Ardalis.SmartEnum.Serialization</RootNamespace>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <LangVersion>7.3</LangVersion>
+    <Features>strict</Features>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SmartEnum\SmartEnum.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="All" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="7.9.0.7583" PrivateAssets="All" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
+    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
+  </ItemGroup>
+</Project>

--- a/src/SmartEnum.Serialization/SmartEnumSurrogate.cs
+++ b/src/SmartEnum.Serialization/SmartEnumSurrogate.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace Ardalis.SmartEnum.Serialization
+{
+    public class SmartEnumSurrogateProvider<TEnum, TValue> : ISerializationSurrogateProvider
+        where TEnum : SmartEnum<TEnum, TValue>
+        where TValue : struct, IEquatable<TValue>, IComparable<TValue>
+    {
+        public Type GetSurrogateType(Type type)
+        {
+            if (type is TEnum)
+                return typeof(string);
+
+            return type;
+        }
+
+        public object GetDeserializedObject(object obj, Type targetType)
+        {
+            if (obj is null)
+                return null;
+
+            var name = (string)obj;
+            if(!SmartEnum<TEnum, TValue>.TryFromName(name, out var result))
+                throw new SerializationException($"Error converting value '{name}' to a smart enum.");
+
+            return result;
+        }
+
+        public object GetObjectToSerialize(object obj, Type targetType)
+        {
+            if (obj is null)
+                return null;
+
+            var smartEnum = (SmartEnum<TEnum, TValue>)obj;
+            return smartEnum.Name;
+        }
+    }
+}

--- a/src/SmartEnum.sln
+++ b/src/SmartEnum.sln
@@ -37,6 +37,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SmartEnum.Utf8Json", "Smart
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SmartEnum.Utf8Json.UnitTests", "SmartEnum.Utf8Json.UnitTests\SmartEnum.Utf8Json.UnitTests.csproj", "{66EF3D1A-32AE-4B28-BC3E-7441615722A9}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SmartEnum.Serialization", "SmartEnum.Serialization\SmartEnum.Serialization.csproj", "{F2DBAC0C-16A7-4E51-A4B4-10D25913DE40}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SmartEnum.Serialization.UnitTests", "SmartEnum.Serialization.UnitTests\SmartEnum.Serialization.UnitTests.csproj", "{4F8630B9-45BB-492E-B921-40860CDF3BA8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -95,6 +99,14 @@ Global
 		{66EF3D1A-32AE-4B28-BC3E-7441615722A9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{66EF3D1A-32AE-4B28-BC3E-7441615722A9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{66EF3D1A-32AE-4B28-BC3E-7441615722A9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F2DBAC0C-16A7-4E51-A4B4-10D25913DE40}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F2DBAC0C-16A7-4E51-A4B4-10D25913DE40}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F2DBAC0C-16A7-4E51-A4B4-10D25913DE40}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F2DBAC0C-16A7-4E51-A4B4-10D25913DE40}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4F8630B9-45BB-492E-B921-40860CDF3BA8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4F8630B9-45BB-492E-B921-40860CDF3BA8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4F8630B9-45BB-492E-B921-40860CDF3BA8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4F8630B9-45BB-492E-B921-40860CDF3BA8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
**Work In Progress, do not merge!**

@raleighbuckner I've been trying to add serialization support to multiple protocols/libraries as separate NuGet packages so that no unnecessary dependencies are added to users' projects.

This PR adds a project that contains a [ISerializationSurrogateProvider](https://docs.microsoft.com/en-us/dotnet/api/system.runtime.serialization.iserializationsurrogateprovider) implementation for SmartEnums. Does this work for WCF?
