### PR TITLE
Remove the struct restriction for TValue

### DIFF
--- a/src/SmartEnum.UnitTests/SmartEnumStringEquals.cs
+++ b/src/SmartEnum.UnitTests/SmartEnumStringEquals.cs
@@ -9,13 +9,10 @@ namespace Ardalis.SmartEnum.UnitTests
         public static TheoryData<TestStringEnum, object, bool> EqualsTestEnumObjectData =>
             new TheoryData<TestStringEnum, object, bool> 
             {
-                { TestStringEnum.Null, null, false },
                 { TestStringEnum.One, null, false },
-                { TestStringEnum.Null, TestStringEnum.Null, true },
-                { TestStringEnum.Null, TestStringEnum.One, false },
-                { TestStringEnum.One, TestStringEnum.Null, false },
-                { TestStringEnum.Null, TestEnum.One, false },
                 { TestStringEnum.One, TestEnum.One, false },
+                { TestStringEnum.One, TestStringEnum.One, true },
+                { TestStringEnum.One, TestStringEnum.Two, false },
             };
 
         [Theory]
@@ -30,10 +27,9 @@ namespace Ardalis.SmartEnum.UnitTests
         public static TheoryData<TestStringEnum, TestStringEnum, bool> EqualsSmartEnumData =>
             new TheoryData<TestStringEnum, TestStringEnum, bool> 
             {
-                { TestStringEnum.Null, null, false },
                 { TestStringEnum.One, null, false },
-                { TestStringEnum.Null, TestStringEnum.Null, true },
-                { TestStringEnum.Null, TestStringEnum.One, false },
+                { TestStringEnum.One, TestStringEnum.One, true },
+                { TestStringEnum.One, TestStringEnum.Two, false },
             };
 
         [Theory]
@@ -49,12 +45,10 @@ namespace Ardalis.SmartEnum.UnitTests
             new TheoryData<TestStringEnum, TestStringEnum, bool> 
             {
                 { null, null, true },
-                { null, TestStringEnum.Null, false },
                 { null, TestStringEnum.One, false },
-                { TestStringEnum.Null, null, false },
                 { TestStringEnum.One, null, false },
-                { TestStringEnum.Null, TestStringEnum.Null, true },
-                { TestStringEnum.Null, TestStringEnum.One, false },
+                { TestStringEnum.One, TestStringEnum.One, true },
+                { TestStringEnum.One, TestStringEnum.Two, false },
             };
 
         [Theory]

--- a/src/SmartEnum.UnitTests/SmartEnumStringEquals.cs
+++ b/src/SmartEnum.UnitTests/SmartEnumStringEquals.cs
@@ -1,0 +1,78 @@
+namespace Ardalis.SmartEnum.UnitTests
+{
+    using System;
+    using FluentAssertions;
+    using Xunit;
+
+    public class SmartEnumStringEquals
+    {
+        public static TheoryData<TestStringEnum, object, bool> EqualsTestEnumObjectData =>
+            new TheoryData<TestStringEnum, object, bool> 
+            {
+                { TestStringEnum.Null, null, false },
+                { TestStringEnum.One, null, false },
+                { TestStringEnum.Null, TestStringEnum.Null, true },
+                { TestStringEnum.Null, TestStringEnum.One, false },
+                { TestStringEnum.One, TestStringEnum.Null, false },
+                { TestStringEnum.Null, TestEnum.One, false },
+                { TestStringEnum.One, TestEnum.One, false },
+            };
+
+        [Theory]
+        [MemberData(nameof(EqualsTestEnumObjectData))]
+        public void EqualsObjectReturnsExpected(TestStringEnum left, object right, bool expected)
+        {
+            var result = left.Equals(right);
+
+            result.Should().Be(expected);
+        }
+
+        public static TheoryData<TestStringEnum, TestStringEnum, bool> EqualsSmartEnumData =>
+            new TheoryData<TestStringEnum, TestStringEnum, bool> 
+            {
+                { TestStringEnum.Null, null, false },
+                { TestStringEnum.One, null, false },
+                { TestStringEnum.Null, TestStringEnum.Null, true },
+                { TestStringEnum.Null, TestStringEnum.One, false },
+            };
+
+        [Theory]
+        [MemberData(nameof(EqualsSmartEnumData))]
+        public void EqualsSmartEnumReturnsExpected(TestStringEnum left, TestStringEnum right, bool expected)
+        {
+            var result = left.Equals(right);
+
+            result.Should().Be(expected);
+        }
+
+        public static TheoryData<TestStringEnum, TestStringEnum, bool> EqualOperatorData =>
+            new TheoryData<TestStringEnum, TestStringEnum, bool> 
+            {
+                { null, null, true },
+                { null, TestStringEnum.Null, false },
+                { null, TestStringEnum.One, false },
+                { TestStringEnum.Null, null, false },
+                { TestStringEnum.One, null, false },
+                { TestStringEnum.Null, TestStringEnum.Null, true },
+                { TestStringEnum.Null, TestStringEnum.One, false },
+            };
+
+        [Theory]
+        [MemberData(nameof(EqualOperatorData))]
+        public void EqualOperatorReturnsExpected(TestStringEnum left, TestStringEnum right, bool expected)
+        {
+            var result = left == right;
+
+            result.Should().Be(expected);
+        }
+
+        [Theory]
+        [MemberData(nameof(EqualOperatorData))]
+        public void NotEqualOperatorReturnsExpected(TestStringEnum left, TestStringEnum right, bool expected)
+        {
+            var result = left != right;
+
+            result.Should().Be(!expected);
+        }
+    }
+} 

--- a/src/SmartEnum.UnitTests/SmartEnumStringFromValue.cs
+++ b/src/SmartEnum.UnitTests/SmartEnumStringFromValue.cs
@@ -1,0 +1,49 @@
+﻿namespace Ardalis.SmartEnum.UnitTests
+{
+    using System;
+    using FluentAssertions;
+    using Xunit;
+
+    public class SmartEnumStringFromValue
+    {
+        public static TheoryData<string, TestStringEnum> TestStringEnumData =>
+            new TheoryData<string, TestStringEnum>
+            {
+                { nameof(TestStringEnum.One), TestStringEnum.One },
+                { nameof(TestStringEnum.Two), TestStringEnum.Two },
+            };
+
+        [Theory]
+        [MemberData(nameof(TestStringEnumData))]
+        public void ReturnsEnumGivenMatchingValue(string value, TestStringEnum expected)
+        {
+            var result = TestStringEnum.FromValue(value);
+
+            result.Should().BeSameAs(expected);
+        }
+
+        [Fact]
+        public void ThrowsGivenNonMatchingValue()
+        {
+            var value = string.Empty;
+
+            Action action = () => TestStringEnum.FromValue(value);
+            
+            action.Should()
+            .ThrowExactly<SmartEnumNotFoundException>()
+            .WithMessage($"No {typeof(TestStringEnum).Name} with Value {value} found.");
+
+        }
+
+        [Fact]
+        public void ReturnsDefaultEnumGivenNonMatchingValue()
+        {
+            var value = string.Empty;
+            var defaultEnum = TestStringEnum.One;
+
+            var result = TestStringEnum.FromValue(value, defaultEnum);
+
+            result.Should().BeSameAs(defaultEnum);
+        }
+    }
+}

--- a/src/SmartEnum.UnitTests/TestEnum.cs
+++ b/src/SmartEnum.UnitTests/TestEnum.cs
@@ -41,7 +41,6 @@
 
     public class TestStringEnum : SmartEnum<TestStringEnum, string>
     {
-        public static readonly TestStringEnum Null = new TestStringEnum(nameof(Null), null);
         public static readonly TestStringEnum One = new TestStringEnum(nameof(One), nameof(One));
         public static readonly TestStringEnum Two = new TestStringEnum(nameof(Two), nameof(Two));
         public static readonly TestStringEnum Three = new TestStringEnum(nameof(Three), nameof(Three));

--- a/src/SmartEnum.UnitTests/TestEnum.cs
+++ b/src/SmartEnum.UnitTests/TestEnum.cs
@@ -38,4 +38,17 @@
         public static new TestBaseEnum FromName(string name, bool ignoreCase = false) =>
             TestBaseEnum.FromName(name, ignoreCase);
     }
+
+    public class TestStringEnum : SmartEnum<TestStringEnum, string>
+    {
+        public static readonly TestStringEnum Null = new TestStringEnum(nameof(Null), null);
+        public static readonly TestStringEnum One = new TestStringEnum(nameof(One), nameof(One));
+        public static readonly TestStringEnum Two = new TestStringEnum(nameof(Two), nameof(Two));
+        public static readonly TestStringEnum Three = new TestStringEnum(nameof(Three), nameof(Three));
+
+        protected TestStringEnum(string name, string value) : base(name, value)
+        {
+        }
+    }
+
 }

--- a/src/SmartEnum/SmartEnum.cs
+++ b/src/SmartEnum/SmartEnum.cs
@@ -243,7 +243,10 @@
         public static bool TryFromValue(TValue value, out TEnum result)
         {
             if (value == null)
-                throw new ArgumentNullException(nameof(value));
+            {
+                result = default;
+                return false;
+            }
 
             return _fromValue.Value.TryGetValue(value, out result);
         }

--- a/src/SmartEnum/SmartEnum.cs
+++ b/src/SmartEnum/SmartEnum.cs
@@ -93,7 +93,7 @@
         {
             if (String.IsNullOrEmpty(name))
                 throw new ArgumentException("Argument cannot be null or empty.", nameof(name));
-            if (value is null)
+            if (value == null)
                 throw new ArgumentNullException(nameof(value));
 
             _name = name;
@@ -195,7 +195,7 @@
         /// <seealso cref="SmartEnum{TEnum, TValue}.TryFromValue(TValue, out TEnum)"/>
         public static TEnum FromValue(TValue value)
         {
-            if (value is null)
+            if (value == null)
                 throw new ArgumentNullException(nameof(value));
 
             if (!_fromValue.Value.TryGetValue(value, out var result))
@@ -218,7 +218,7 @@
         /// <seealso cref="SmartEnum{TEnum, TValue}.TryFromValue(TValue, out TEnum)"/>
         public static TEnum FromValue(TValue value, TEnum defaultValue)
         {
-            if (value is null)
+            if (value == null)
                 throw new ArgumentNullException(nameof(value));
 
             if (!_fromValue.Value.TryGetValue(value, out var result))
@@ -242,7 +242,7 @@
         /// <seealso cref="SmartEnum{TEnum, TValue}.FromValue(TValue, TEnum)"/>
         public static bool TryFromValue(TValue value, out TEnum result)
         {
-            if (value is null)
+            if (value == null)
                 throw new ArgumentNullException(nameof(value));
 
             return _fromValue.Value.TryGetValue(value, out result);

--- a/src/SmartEnum/SmartEnum.cs
+++ b/src/SmartEnum/SmartEnum.cs
@@ -93,7 +93,9 @@
         {
             if (String.IsNullOrEmpty(name))
                 throw new ArgumentException("Argument cannot be null or empty.", nameof(name));
-            
+            if (value is null)
+                throw new ArgumentNullException(nameof(value));
+
             _name = name;
             _value = value;
         }
@@ -193,6 +195,9 @@
         /// <seealso cref="SmartEnum{TEnum, TValue}.TryFromValue(TValue, out TEnum)"/>
         public static TEnum FromValue(TValue value)
         {
+            if (value is null)
+                throw new ArgumentNullException(nameof(value));
+
             if (!_fromValue.Value.TryGetValue(value, out var result))
             {
                 throw new SmartEnumNotFoundException($"No {typeof(TEnum).Name} with Value {value} found.");
@@ -213,6 +218,9 @@
         /// <seealso cref="SmartEnum{TEnum, TValue}.TryFromValue(TValue, out TEnum)"/>
         public static TEnum FromValue(TValue value, TEnum defaultValue)
         {
+            if (value is null)
+                throw new ArgumentNullException(nameof(value));
+
             if (!_fromValue.Value.TryGetValue(value, out var result))
             {
                 return defaultValue;
@@ -232,15 +240,20 @@
         /// </returns>
         /// <seealso cref="SmartEnum{TEnum, TValue}.FromValue(TValue)"/>
         /// <seealso cref="SmartEnum{TEnum, TValue}.FromValue(TValue, TEnum)"/>
-        public static bool TryFromValue(TValue value, out TEnum result) =>
-            _fromValue.Value.TryGetValue(value, out result);
+        public static bool TryFromValue(TValue value, out TEnum result)
+        {
+            if (value is null)
+                throw new ArgumentNullException(nameof(value));
+
+            return _fromValue.Value.TryGetValue(value, out result);
+        }
 
         public override string ToString() => 
             _name;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public override int GetHashCode() =>
-            _value?.GetHashCode() ?? 0; 
+            _value.GetHashCode(); 
 
         public override bool Equals(object obj) => 
             (obj is SmartEnum<TEnum, TValue> other) && Equals(other);
@@ -260,9 +273,6 @@
             // check if it's not null and is same value
             if (other is null)
                 return false;
-
-            if (_value is null)
-                return (other._value is null);
 
             return _value.Equals(other._value);
         }

--- a/src/SmartEnum/SmartEnum.cs
+++ b/src/SmartEnum/SmartEnum.cs
@@ -31,7 +31,7 @@
         IEquatable<SmartEnum<TEnum, TValue>>,
         IComparable<SmartEnum<TEnum, TValue>>
         where TEnum : SmartEnum<TEnum, TValue>
-        where TValue : struct, IEquatable<TValue>, IComparable<TValue>
+        where TValue : IEquatable<TValue>, IComparable<TValue>
     {
         static readonly Lazy<Dictionary<string, TEnum>> _fromName = 
             new Lazy<Dictionary<string, TEnum>>(() => GetAllOptions().ToDictionary(item => item.Name));
@@ -240,7 +240,7 @@
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public override int GetHashCode() =>
-            _value.GetHashCode(); 
+            _value?.GetHashCode() ?? 0; 
 
         public override bool Equals(object obj) => 
             (obj is SmartEnum<TEnum, TValue> other) && Equals(other);
@@ -260,6 +260,9 @@
             // check if it's not null and is same value
             if (other is null)
                 return false;
+
+            if (_value is null)
+                return (other._value is null);
 
             return _value.Equals(other._value);
         }
@@ -310,9 +313,5 @@
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static explicit operator SmartEnum<TEnum, TValue>(TValue value) => 
             FromValue(value);
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static explicit operator SmartEnum<TEnum, TValue>(TValue? value) => 
-            value.HasValue ? FromValue(value.Value) : null;    
     }
 }


### PR DESCRIPTION
This change allows reference types to be used for value, including strings.

Fixes #42 

Please review
@ardalis @robertstefan