### PR TITLE
Support Hierarchical Enums in List Method

### DIFF
--- a/src/SmartEnum.UnitTests/SmartEnumExplicitConversion.cs
+++ b/src/SmartEnum.UnitTests/SmartEnumExplicitConversion.cs
@@ -1,4 +1,5 @@
-﻿using Xunit;
+﻿using SmartEnum.UnitTests.TestEnums;
+using Xunit;
 
 namespace SmartEnum.UnitTests
 {

--- a/src/SmartEnum.UnitTests/SmartEnumFromConstructor.cs
+++ b/src/SmartEnum.UnitTests/SmartEnumFromConstructor.cs
@@ -1,4 +1,5 @@
-﻿using Xunit;
+﻿using SmartEnum.UnitTests.TestEnums;
+using Xunit;
 
 namespace SmartEnum.UnitTests
 {
@@ -17,7 +18,7 @@ namespace SmartEnum.UnitTests
         {
             var expected = TestEnum.One;
 
-            Assert.NotEqual(expected, TestEnum.CreateFromConstructor("Two", 2));            
+            Assert.NotEqual(expected, TestEnum.CreateFromConstructor("Two", 2));
         }
     }
 }

--- a/src/SmartEnum.UnitTests/SmartEnumFromName.cs
+++ b/src/SmartEnum.UnitTests/SmartEnumFromName.cs
@@ -1,4 +1,5 @@
 ﻿using SmartEnum.Exceptions;
+using SmartEnum.UnitTests.TestEnums;
 using System;
 using Xunit;
 

--- a/src/SmartEnum.UnitTests/SmartEnumFromValue.cs
+++ b/src/SmartEnum.UnitTests/SmartEnumFromValue.cs
@@ -43,5 +43,13 @@ namespace SmartEnum.UnitTests
 
             Assert.Equal(defaultEnum, TestEnum.FromValue(-1, defaultEnum));
         }
+
+        [Fact]
+        public void ReturnsDerivedEnumByValue()
+        {
+            BaseTestEnum result = DerivedTestEnum1.FromValue(1);
+
+            Assert.Equal(DerivedTestEnum1.A, result);
+        }
     }
 }

--- a/src/SmartEnum.UnitTests/SmartEnumFromValue.cs
+++ b/src/SmartEnum.UnitTests/SmartEnumFromValue.cs
@@ -1,4 +1,5 @@
 ﻿using SmartEnum.Exceptions;
+using SmartEnum.UnitTests.TestEnums;
 using Xunit;
 
 namespace SmartEnum.UnitTests

--- a/src/SmartEnum.UnitTests/SmartEnumImplicitValueConversion.cs
+++ b/src/SmartEnum.UnitTests/SmartEnumImplicitValueConversion.cs
@@ -1,4 +1,5 @@
-﻿using Xunit;
+﻿using SmartEnum.UnitTests.TestEnums;
+using Xunit;
 
 namespace SmartEnum.UnitTests
 {

--- a/src/SmartEnum.UnitTests/SmartEnumList.cs
+++ b/src/SmartEnum.UnitTests/SmartEnumList.cs
@@ -1,4 +1,4 @@
-﻿using Ardalis.SmartEnum;
+﻿using SmartEnum.UnitTests.TestEnums;
 using Xunit;
 
 namespace SmartEnum.UnitTests
@@ -19,34 +19,13 @@ namespace SmartEnum.UnitTests
         [Fact]
         public void ReturnsAllEnumsFromDerivedTypes()
         {
-            var result = BaseEnum.List;
+            var result = BaseTestEnum.List;
 
             Assert.Equal(4, result.Count);
-            Assert.Contains(DerivedEnum1.A, result);
-            Assert.Contains(DerivedEnum1.B, result);
-            Assert.Contains(DerivedEnum2.C, result);
-            Assert.Contains(DerivedEnum2.D, result);
-        }
-
-        private abstract class BaseEnum : SmartEnum<BaseEnum, int>
-        {
-            protected BaseEnum(string name, int value) : base(name, value) { }
-        }
-
-        private class DerivedEnum1 : BaseEnum
-        {
-            private DerivedEnum1(string name, int value) : base(name, value) { }
-
-            public static readonly DerivedEnum1 A = new DerivedEnum1("A", 1);
-            public static readonly DerivedEnum1 B = new DerivedEnum1("B", 2);
-        }
-
-        private class DerivedEnum2 : BaseEnum
-        {
-            private DerivedEnum2(string name, int value) : base(name, value) { }
-
-            public static readonly DerivedEnum2 C = new DerivedEnum2("C", 3);
-            public static readonly DerivedEnum2 D = new DerivedEnum2("D", 4);
+            Assert.Contains(DerivedTestEnum1.A, result);
+            Assert.Contains(DerivedTestEnum1.B, result);
+            Assert.Contains(DerivedTestEnum2.C, result);
+            Assert.Contains(DerivedTestEnum2.D, result);
         }
     }
 }

--- a/src/SmartEnum.UnitTests/SmartEnumList.cs
+++ b/src/SmartEnum.UnitTests/SmartEnumList.cs
@@ -1,4 +1,5 @@
-﻿using Xunit;
+﻿using Ardalis.SmartEnum;
+using Xunit;
 
 namespace SmartEnum.UnitTests
 {
@@ -13,6 +14,39 @@ namespace SmartEnum.UnitTests
             Assert.Contains(TestEnum.One, result);
             Assert.Contains(TestEnum.Two, result);
             Assert.Contains(TestEnum.Three, result);
+        }
+
+        [Fact]
+        public void ReturnsAllEnumsFromDerivedTypes()
+        {
+            var result = BaseEnum.List;
+
+            Assert.Equal(4, result.Count);
+            Assert.Contains(DerivedEnum1.A, result);
+            Assert.Contains(DerivedEnum1.B, result);
+            Assert.Contains(DerivedEnum2.C, result);
+            Assert.Contains(DerivedEnum2.D, result);
+        }
+
+        private abstract class BaseEnum : SmartEnum<BaseEnum, int>
+        {
+            protected BaseEnum(string name, int value) : base(name, value) { }
+        }
+
+        private class DerivedEnum1 : BaseEnum
+        {
+            private DerivedEnum1(string name, int value) : base(name, value) { }
+
+            public static readonly DerivedEnum1 A = new DerivedEnum1("A", 1);
+            public static readonly DerivedEnum1 B = new DerivedEnum1("B", 2);
+        }
+
+        private class DerivedEnum2 : BaseEnum
+        {
+            private DerivedEnum2(string name, int value) : base(name, value) { }
+
+            public static readonly DerivedEnum2 C = new DerivedEnum2("C", 3);
+            public static readonly DerivedEnum2 D = new DerivedEnum2("D", 4);
         }
     }
 }

--- a/src/SmartEnum.UnitTests/SmartEnumToString.cs
+++ b/src/SmartEnum.UnitTests/SmartEnumToString.cs
@@ -1,4 +1,5 @@
-﻿using Xunit;
+﻿using SmartEnum.UnitTests.TestEnums;
+using Xunit;
 
 namespace SmartEnum.UnitTests
 {

--- a/src/SmartEnum.UnitTests/SmartEnumValueSetter.cs
+++ b/src/SmartEnum.UnitTests/SmartEnumValueSetter.cs
@@ -1,4 +1,5 @@
-﻿using Xunit;
+﻿using SmartEnum.UnitTests.TestEnums;
+using Xunit;
 
 namespace SmartEnum.UnitTests
 {

--- a/src/SmartEnum.UnitTests/TestEnums/BaseTestEnum.cs
+++ b/src/SmartEnum.UnitTests/TestEnums/BaseTestEnum.cs
@@ -1,0 +1,9 @@
+﻿using Ardalis.SmartEnum;
+
+namespace SmartEnum.UnitTests.TestEnums
+{
+    internal abstract class BaseTestEnum : SmartEnum<BaseTestEnum, int>
+    {
+        protected BaseTestEnum(string name, int value) : base(name, value) { }
+    }
+}

--- a/src/SmartEnum.UnitTests/TestEnums/DerivedTestEnum1.cs
+++ b/src/SmartEnum.UnitTests/TestEnums/DerivedTestEnum1.cs
@@ -1,0 +1,10 @@
+﻿namespace SmartEnum.UnitTests.TestEnums
+{
+    internal class DerivedTestEnum1 : BaseTestEnum
+    {
+        private DerivedTestEnum1(string name, int value) : base(name, value) { }
+
+        public static readonly DerivedTestEnum1 A = new DerivedTestEnum1("A", 1);
+        public static readonly DerivedTestEnum1 B = new DerivedTestEnum1("B", 2);
+    }
+}

--- a/src/SmartEnum.UnitTests/TestEnums/DerivedTestEnum1.cs
+++ b/src/SmartEnum.UnitTests/TestEnums/DerivedTestEnum1.cs
@@ -4,7 +4,7 @@
     {
         private DerivedTestEnum1(string name, int value) : base(name, value) { }
 
-        public static readonly DerivedTestEnum1 A = new DerivedTestEnum1("A", 1);
-        public static readonly DerivedTestEnum1 B = new DerivedTestEnum1("B", 2);
+        public static readonly DerivedTestEnum1 A = new DerivedTestEnum1(nameof(A), 1);
+        public static readonly DerivedTestEnum1 B = new DerivedTestEnum1(nameof(B), 2);
     }
 }

--- a/src/SmartEnum.UnitTests/TestEnums/DerivedTestEnum2.cs
+++ b/src/SmartEnum.UnitTests/TestEnums/DerivedTestEnum2.cs
@@ -1,0 +1,10 @@
+﻿namespace SmartEnum.UnitTests.TestEnums
+{
+    internal class DerivedTestEnum2 : BaseTestEnum
+    {
+        private DerivedTestEnum2(string name, int value) : base(name, value) { }
+
+        public static readonly DerivedTestEnum2 C = new DerivedTestEnum2("C", 3);
+        public static readonly DerivedTestEnum2 D = new DerivedTestEnum2("D", 4);
+    }
+}

--- a/src/SmartEnum.UnitTests/TestEnums/DerivedTestEnum2.cs
+++ b/src/SmartEnum.UnitTests/TestEnums/DerivedTestEnum2.cs
@@ -4,7 +4,7 @@
     {
         private DerivedTestEnum2(string name, int value) : base(name, value) { }
 
-        public static readonly DerivedTestEnum2 C = new DerivedTestEnum2("C", 3);
-        public static readonly DerivedTestEnum2 D = new DerivedTestEnum2("D", 4);
+        public static readonly DerivedTestEnum2 C = new DerivedTestEnum2(nameof(C), 3);
+        public static readonly DerivedTestEnum2 D = new DerivedTestEnum2(nameof(D), 4);
     }
 }

--- a/src/SmartEnum.UnitTests/TestEnums/MutableTestEnum.cs
+++ b/src/SmartEnum.UnitTests/TestEnums/MutableTestEnum.cs
@@ -1,6 +1,6 @@
 ﻿using Ardalis.SmartEnum;
 
-namespace SmartEnum.UnitTests
+namespace SmartEnum.UnitTests.TestEnums
 {
     public class MutableTestEnum : SmartEnum<MutableTestEnum, string>
     {

--- a/src/SmartEnum.UnitTests/TestEnums/MutableTestEnum.cs
+++ b/src/SmartEnum.UnitTests/TestEnums/MutableTestEnum.cs
@@ -2,13 +2,11 @@
 
 namespace SmartEnum.UnitTests.TestEnums
 {
-    public class MutableTestEnum : SmartEnum<MutableTestEnum, string>
+    internal class MutableTestEnum : SmartEnum<MutableTestEnum, string>
     {
         public static MutableTestEnum Hello = new MutableTestEnum(nameof(Hello), "Hello");
 
-        protected MutableTestEnum(string name, string value) : base(name, value)
-        {
-        }
+        private MutableTestEnum(string name, string value) : base(name, value) { }
 
         public void SetValue(string value)
         {

--- a/src/SmartEnum.UnitTests/TestEnums/TestEnum.cs
+++ b/src/SmartEnum.UnitTests/TestEnums/TestEnum.cs
@@ -2,15 +2,13 @@
 
 namespace SmartEnum.UnitTests.TestEnums
 {
-    public class TestEnum : SmartEnum<TestEnum, int>
+    internal class TestEnum : SmartEnum<TestEnum, int>
     {
-        public static TestEnum One = new TestEnum(nameof(One), 1);
-        public static TestEnum Two = new TestEnum(nameof(Two), 2);
-        public static TestEnum Three = new TestEnum(nameof(Three), 3);
+        public static readonly TestEnum One = new TestEnum(nameof(One), 1);
+        public static readonly TestEnum Two = new TestEnum(nameof(Two), 2);
+        public static readonly TestEnum Three = new TestEnum(nameof(Three), 3);
 
-        protected TestEnum(string name, int value) : base(name, value)
-        {
-        }
+        private TestEnum(string name, int value) : base(name, value) { }
 
         private TestEnum() : base()
         {

--- a/src/SmartEnum.UnitTests/TestEnums/TestEnum.cs
+++ b/src/SmartEnum.UnitTests/TestEnums/TestEnum.cs
@@ -1,6 +1,6 @@
 ﻿using Ardalis.SmartEnum;
 
-namespace SmartEnum.UnitTests
+namespace SmartEnum.UnitTests.TestEnums
 {
     public class TestEnum : SmartEnum<TestEnum, int>
     {

--- a/src/SmartEnum/SmartEnum.cs
+++ b/src/SmartEnum/SmartEnum.cs
@@ -26,8 +26,8 @@ namespace Ardalis.SmartEnum
             List<TEnum> options = new List<TEnum>();
             foreach (Type enumType in enumTypes)
             {
-                List<TEnum> derivedTypeEnums = enumType.GetFieldsOfType<TEnum>();
-                options.AddRange(derivedTypeEnums);
+                List<TEnum> typeEnumOptions = enumType.GetFieldsOfType<TEnum>();
+                options.AddRange(typeEnumOptions);
             }
 
             return options.OrderBy(t => t.Name).ToList();

--- a/src/SmartEnum/SmartEnum.cs
+++ b/src/SmartEnum/SmartEnum.cs
@@ -20,12 +20,17 @@ namespace Ardalis.SmartEnum
 
         private static List<TEnum> ListAllOptions()
         {
-            Type t = typeof(TEnum);
-            return t.GetFields(BindingFlags.Public | BindingFlags.Static)
-            .Where(p => t.IsAssignableFrom(p.FieldType))
-            .Select(pi => (TEnum)pi.GetValue(null))
-            .OrderBy(p => p.Name)
-            .ToList();
+            Type baseType = typeof(TEnum);
+            IEnumerable<Type> enumTypes = Assembly.GetAssembly(baseType).GetTypes().Where(t => baseType.IsAssignableFrom(t));
+
+            List<TEnum> options = new List<TEnum>();
+            foreach (Type enumType in enumTypes)
+            {
+                List<TEnum> derivedTypeEnums = enumType.GetFieldsOfType<TEnum>();
+                options.AddRange(derivedTypeEnums);
+            }
+
+            return options.OrderBy(t => t.Name).ToList();
         }
 
         public static List<TEnum> List => _list.Value;

--- a/src/SmartEnum/TypeExtensions.cs
+++ b/src/SmartEnum/TypeExtensions.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Ardalis.SmartEnum
+{
+    public static class TypeExtensions
+    {
+        public static List<TFieldType> GetFieldsOfType<TFieldType>(this Type type)
+        {
+            return type.GetFields(BindingFlags.Public | BindingFlags.Static)
+                .Where(p => type.IsAssignableFrom(p.FieldType))
+                .Select(pi => (TFieldType)pi.GetValue(null))
+                .ToList();
+        }
+    }
+}

--- a/src/SmartEnum/TypeExtensions.cs
+++ b/src/SmartEnum/TypeExtensions.cs
@@ -5,7 +5,7 @@ using System.Reflection;
 
 namespace Ardalis.SmartEnum
 {
-    public static class TypeExtensions
+    internal static class TypeExtensions
     {
         public static List<TFieldType> GetFieldsOfType<TFieldType>(this Type type)
         {


### PR DESCRIPTION
* `List` now contains all derived enum values from a base enum type as well as items from the base
* Also makes `FromValue` correctly find derived enums