### PR TITLE
SmartEnum Hierarchy Support in List

### DIFF
--- a/src/SmartEnum.UnitTests/SmartEnumList.cs
+++ b/src/SmartEnum.UnitTests/SmartEnumList.cs
@@ -16,5 +16,13 @@
                 TestEnum.Three,
             });
         }
+
+        [Fact]
+        public void ReturnsAllBaseAndDerivedSmartEnums()
+        {
+            var result = TestBaseEnumWithDerivedValues.List;
+
+            result.Should().BeEquivalentTo(DerivedTestEnumWithValues1.A, DerivedTestEnumWithValues1.B, DerivedTestEnumWithValues2.C, DerivedTestEnumWithValues2.D);
+        }
     }
 }

--- a/src/SmartEnum.UnitTests/SmartEnumStringFromValue.cs
+++ b/src/SmartEnum.UnitTests/SmartEnumStringFromValue.cs
@@ -1,7 +1,7 @@
 ﻿namespace Ardalis.SmartEnum.UnitTests
 {
-    using System;
     using FluentAssertions;
+    using System;
     using Xunit;
 
     public class SmartEnumStringFromValue
@@ -28,7 +28,7 @@
             var value = string.Empty;
 
             Action action = () => TestStringEnum.FromValue(value);
-            
+
             action.Should()
             .ThrowExactly<SmartEnumNotFoundException>()
             .WithMessage($"No {typeof(TestStringEnum).Name} with Value {value} found.");
@@ -44,6 +44,14 @@
             var result = TestStringEnum.FromValue(value, defaultEnum);
 
             result.Should().BeSameAs(defaultEnum);
+        }
+
+        [Fact]
+        public void ReturnsDerivedEnumByValue()
+        {
+            TestBaseEnumWithDerivedValues result = DerivedTestEnumWithValues1.FromValue(1);
+
+            Assert.Equal(DerivedTestEnumWithValues1.A, result);
         }
     }
 }

--- a/src/SmartEnum.UnitTests/TestEnum.cs
+++ b/src/SmartEnum.UnitTests/TestEnum.cs
@@ -50,4 +50,25 @@
         }
     }
 
+    public class TestBaseEnumWithDerivedValues : SmartEnum<TestBaseEnumWithDerivedValues>
+    {
+        protected TestBaseEnumWithDerivedValues(string name, int value) : base(name, value)
+        { }
+    }
+
+    public class DerivedTestEnumWithValues1 : TestBaseEnumWithDerivedValues
+    {
+        public static readonly DerivedTestEnumWithValues1 A = new DerivedTestEnumWithValues1(nameof(A), 1);
+        public static readonly DerivedTestEnumWithValues1 B = new DerivedTestEnumWithValues1(nameof(B), 1);
+
+        private DerivedTestEnumWithValues1(string name, int value) : base(name, value) { }
+    }
+
+    public class DerivedTestEnumWithValues2 : TestBaseEnumWithDerivedValues
+    {
+        public static readonly DerivedTestEnumWithValues2 C = new DerivedTestEnumWithValues2(nameof(C), 1);
+        public static readonly DerivedTestEnumWithValues2 D = new DerivedTestEnumWithValues2(nameof(D), 1);
+
+        private DerivedTestEnumWithValues2(string name, int value) : base(name, value) { }
+    }
 }

--- a/src/SmartEnum/SmartEnum.cs
+++ b/src/SmartEnum/SmartEnum.cs
@@ -51,17 +51,19 @@
                 return dictionary;
             });
 
-        static IEnumerable<TEnum> GetAllOptions()
+        private static IEnumerable<TEnum> GetAllOptions()
         {
-            Type type = typeof(TEnum);
-            foreach (var fieldInfo in type.GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy))
+            Type baseType = typeof(TEnum);
+            IEnumerable<Type> enumTypes = Assembly.GetAssembly(baseType).GetTypes().Where(t => baseType.IsAssignableFrom(t));
+
+            List<TEnum> options = new List<TEnum>();
+            foreach (Type enumType in enumTypes)
             {
-                object obj = fieldInfo.GetValue(null);
-                if (obj is TEnum value)
-                {
-                    yield return value;
-                }
+                List<TEnum> typeEnumOptions = enumType.GetFieldsOfType<TEnum>();
+                options.AddRange(typeEnumOptions);
             }
+
+            return options.OrderBy(t => t.Name).ToList();
         }
 
         /// <summary>

--- a/src/SmartEnum/TypeExtensions.cs
+++ b/src/SmartEnum/TypeExtensions.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Ardalis.SmartEnum
+{
+    internal static class TypeExtensions
+    {
+        public static List<TFieldType> GetFieldsOfType<TFieldType>(this Type type)
+        {
+            return type.GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)
+                .Where(p => type.IsAssignableFrom(p.FieldType))
+                .Select(pi => (TFieldType)pi.GetValue(null))
+                .ToList();
+        }
+    }
+}


### PR DESCRIPTION
* Relates to issue brought up in #49
* SmartEnum.List now returns values in base and derived types
* `FromValue` also confirmed to work.