### PR TITLE
Remove ardalis.guardclauses from package references

### DIFF
--- a/src/SmartEnum/SmartEnum.csproj
+++ b/src/SmartEnum/SmartEnum.csproj
@@ -32,7 +32,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ardalis.GuardClauses" Version="1.2.8" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="All" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="7.9.0.7583" PrivateAssets="All" />
   </ItemGroup>


### PR DESCRIPTION
Removed reference to ardalis.guardclauses from all projects in solution. 
Ran tests to ensure no breaking changes.

This PR is opened in reference to issue #57.