### PR TITLE
Update TryFromName method

### DIFF
--- a/src/SmartEnum/SmartEnum.cs
+++ b/src/SmartEnum/SmartEnum.cs
@@ -180,7 +180,10 @@
         public static bool TryFromName(string name, bool ignoreCase, out TEnum result)
         {
             if (String.IsNullOrEmpty(name))
-                ThrowHelper.ThrowArgumentNullOrEmptyException(nameof(name));
+            {
+                result = default;
+                return false;
+            }
 
             if (ignoreCase)
                 return _fromNameIgnoreCase.Value.TryGetValue(name, out result);

--- a/test/SmartEnum.UnitTests/SmartEnumTryFromName.cs
+++ b/test/SmartEnum.UnitTests/SmartEnumTryFromName.cs
@@ -1,0 +1,57 @@
+namespace Ardalis.SmartEnum.UnitTests
+{
+    using System;
+    using FluentAssertions;
+    using Xunit;
+
+    public class SmartEnumTryFromName
+    {
+        [Fact]
+        public void ReturnsTrueGivenMatchingName()
+        {
+            var result = TestEnum.TryFromName("One", out var _);
+
+            result.Should().BeTrue();
+        }
+
+        [Fact]
+        public void ProducesEnumGivenMatchingName()
+        {
+            TestEnum.TryFromName("One", out var result);
+
+            result.Should().BeSameAs(TestEnum.One);
+        }
+
+        [Fact]
+        public void ReturnsFalseGivenEmptyString()
+        {
+            var result = TestEnum.TryFromName(String.Empty, out var _);
+
+            result.Should().BeFalse();
+        }
+
+        [Fact]
+        public void ProducesNullGivenEmptyString()
+        {
+            TestEnum.TryFromName(String.Empty, out var result);
+
+            result.Should().BeNull();
+        }
+
+        [Fact]
+        public void ReturnsFalseGivenNull()
+        {
+            var result = TestEnum.TryFromName(null, out var _);
+
+            result.Should().BeFalse();
+        }
+
+        [Fact]
+        public void ProducesNullGivenNull()
+        {
+            TestEnum.TryFromName(null, out var result);
+
+            result.Should().BeNull();
+        }
+    }
+}


### PR DESCRIPTION
Small fix that changes the `TryFromName` behavior so it returns false when the name is null or empty instead of throwing an error. However, it should be considered as breaking change so it might be better to bump the major version number.
Also, the PR contains a few unit tests that cover `TryFromName`

This PR resolves #95 