### PR TITLE
Resolve options from multiple assemblies

### DIFF
--- a/SmartEnum.UnitTests.TestData/SmartEnum.UnitTests.TestData.csproj
+++ b/SmartEnum.UnitTests.TestData/SmartEnum.UnitTests.TestData.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <RootNamespace>Ardalis.SmartEnum.UnitTests.TestData</RootNamespace>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\src\SmartEnum\SmartEnum.csproj" />
+    </ItemGroup>
+    
+    <ItemGroup>
+      <PackageReference Update="FluentAssertions" Version="5.10.3" />
+    </ItemGroup>
+
+</Project>

--- a/SmartEnum.UnitTests.TestData/TestEnum.cs
+++ b/SmartEnum.UnitTests.TestData/TestEnum.cs
@@ -1,8 +1,7 @@
-﻿using System.Runtime.CompilerServices;
-
-namespace Ardalis.SmartEnum.UnitTests
+﻿namespace Ardalis.SmartEnum.UnitTests.TestData
 {
-
+    using System.Runtime.CompilerServices;
+    
     public class TestEnum : SmartEnum<TestEnum>
     {
         public static readonly TestEnum One = new TestEnum(1);
@@ -61,16 +60,39 @@ namespace Ardalis.SmartEnum.UnitTests
     public class DerivedTestEnumWithValues1 : TestBaseEnumWithDerivedValues
     {
         public static readonly DerivedTestEnumWithValues1 A = new DerivedTestEnumWithValues1(nameof(A), 1);
-        public static readonly DerivedTestEnumWithValues1 B = new DerivedTestEnumWithValues1(nameof(B), 1);
+        public static readonly DerivedTestEnumWithValues1 B = new DerivedTestEnumWithValues1(nameof(B), 2);
 
         private DerivedTestEnumWithValues1(string name, int value) : base(name, value) { }
     }
 
     public class DerivedTestEnumWithValues2 : TestBaseEnumWithDerivedValues
     {
-        public static readonly DerivedTestEnumWithValues2 C = new DerivedTestEnumWithValues2(nameof(C), 1);
-        public static readonly DerivedTestEnumWithValues2 D = new DerivedTestEnumWithValues2(nameof(D), 1);
+        public static readonly DerivedTestEnumWithValues2 C = new DerivedTestEnumWithValues2(nameof(C), 3);
+        public static readonly DerivedTestEnumWithValues2 D = new DerivedTestEnumWithValues2(nameof(D), 4);
 
         private DerivedTestEnumWithValues2(string name, int value) : base(name, value) { }
+    }
+    
+    
+    public class AnotherEnumBase : SmartEnum<AnotherEnumBase>
+    {
+        protected AnotherEnumBase(string name, int value) : base(name, value)
+        { }
+    }
+
+    public class AnotherEnumDerived1 : AnotherEnumBase
+    {
+        public static readonly AnotherEnumDerived1 A = new AnotherEnumDerived1(nameof(A), 1);
+        public static readonly AnotherEnumDerived1 B = new AnotherEnumDerived1(nameof(B), 2);
+
+        private AnotherEnumDerived1(string name, int value) : base(name, value) { }
+    }
+    
+    public class AnotherEnumDerived2 : AnotherEnumBase
+    {
+        public static readonly AnotherEnumDerived2 C = new AnotherEnumDerived2(nameof(C), 3);
+        public static readonly AnotherEnumDerived2 D = new AnotherEnumDerived2(nameof(D), 4);
+
+        private AnotherEnumDerived2(string name, int value) : base(name, value) { }
     }
 }

--- a/SmartEnum.sln
+++ b/SmartEnum.sln
@@ -50,6 +50,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{FA199ECB-5F2
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "benchmarks", "benchmarks", "{5952C160-ABAA-4302-9150-0928E82545B1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SmartEnum.UnitTests.TestData", "SmartEnum.UnitTests.TestData\SmartEnum.UnitTests.TestData.csproj", "{0BC8B37F-BEBC-4D11-ACDE-31FBC04ED3D5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -108,6 +110,10 @@ Global
 		{66EF3D1A-32AE-4B28-BC3E-7441615722A9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{66EF3D1A-32AE-4B28-BC3E-7441615722A9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{66EF3D1A-32AE-4B28-BC3E-7441615722A9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0BC8B37F-BEBC-4D11-ACDE-31FBC04ED3D5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0BC8B37F-BEBC-4D11-ACDE-31FBC04ED3D5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0BC8B37F-BEBC-4D11-ACDE-31FBC04ED3D5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0BC8B37F-BEBC-4D11-ACDE-31FBC04ED3D5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -126,6 +132,7 @@ Global
 		{C65837A3-1AB1-4AD4-9D9E-C3FF437A5714} = {79268877-BBEF-4DE2-B8D9-697F21933159}
 		{8FC7B9E5-B651-42BC-B21B-B45F0C8A239B} = {FA199ECB-5F29-442A-AAC6-91DBCB7A5A04}
 		{66EF3D1A-32AE-4B28-BC3E-7441615722A9} = {79268877-BBEF-4DE2-B8D9-697F21933159}
+		{0BC8B37F-BEBC-4D11-ACDE-31FBC04ED3D5} = {79268877-BBEF-4DE2-B8D9-697F21933159}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {46896DE3-41B8-442F-A6FB-6AC9F11CCBCE}

--- a/src/SmartEnum/SmartEnum.csproj
+++ b/src/SmartEnum/SmartEnum.csproj
@@ -18,7 +18,8 @@
     <AssemblyName>Ardalis.SmartEnum</AssemblyName>
     <Features>strict</Features>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>    
+    <RootNamespace>Ardalis.SmartEnum</RootNamespace>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">

--- a/src/SmartEnum/SmartEnumOptions.cs
+++ b/src/SmartEnum/SmartEnumOptions.cs
@@ -1,0 +1,74 @@
+﻿namespace Ardalis.SmartEnum
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    
+    /// <summary>
+    /// Helper type to add enum options stored in multiple assemblies.
+    /// </summary>
+    /// <typeparam name="TEnum">The base type of selected SmartEnum.</typeparam>
+    /// <typeparam name="TValue">The type of the inner value of selected SmartEnum</typeparam>
+    public static class SmartEnumOptions<TEnum, TValue>
+        where TEnum : SmartEnum<TEnum, TValue>
+        where TValue : IEquatable<TValue>, IComparable<TValue>
+    {
+        private static readonly HashSet<TEnum> _options = new HashSet<TEnum>();
+
+        internal static IReadOnlyCollection<TEnum> GetAll()
+        {
+            if (_options.Count == 0)
+                Add(DefaultAssembly);
+            
+            return _options;
+        }
+
+        /// <summary>
+        /// Default assembly to scan.
+        /// </summary>
+        private static Assembly DefaultAssembly => typeof(TEnum).Assembly;
+
+        private static IEnumerable<TEnum> Scan(Assembly assembly, Type baseType)
+        {
+            return assembly
+                .GetTypes()
+                .Where(baseType.IsAssignableFrom)
+                .SelectMany(t => t.GetFieldsOfType<TEnum>());
+        }
+
+        /// <summary>
+        /// Adds enum options by scanning all compatible types in provided <paramref name="assemblies"/>.
+        /// </summary>
+        /// <param name="assemblies"></param>
+        public static void Add(params Assembly[] assemblies)
+        {
+            if (assemblies == null)
+                throw new ArgumentNullException(nameof(assemblies));
+            
+            var baseType = typeof(TEnum);
+            foreach (var derived in assemblies.SelectMany(a => Scan(a, baseType)))
+            {
+                _options.Add(derived);
+            }
+        }
+
+        public static void Clear() => _options.Clear();
+    }
+    
+    public static class SmartEnumOptions
+    {
+        public static void Add<TEnum>(params Assembly[] assemblies)
+            where TEnum : SmartEnum<TEnum>
+        {
+            SmartEnumOptions<TEnum, int>.Add(assemblies);
+        }
+
+        public static void Add<TEnum, TValue>(params Assembly[] assemblies)
+            where TEnum : SmartEnum<TEnum, TValue>
+            where TValue : IEquatable<TValue>, IComparable<TValue>
+        {
+            SmartEnumOptions<TEnum, TValue>.Add(assemblies);    
+        }
+    }
+}

--- a/test/SmartEnum.UnitTests/SmartEnum.UnitTests.csproj
+++ b/test/SmartEnum.UnitTests/SmartEnum.UnitTests.csproj
@@ -4,8 +4,10 @@
     <IsPackable>false</IsPackable>
     <LangVersion>7.3</LangVersion>
     <Features>strict</Features>
+    <RootNamespace>Ardalis.SmartEnum.UnitTests</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\SmartEnum.UnitTests.TestData\SmartEnum.UnitTests.TestData.csproj" />
     <ProjectReference Include="..\..\src\SmartEnum\SmartEnum.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/test/SmartEnum.UnitTests/SmartEnumCompareTo.cs
+++ b/test/SmartEnum.UnitTests/SmartEnumCompareTo.cs
@@ -1,8 +1,10 @@
+
 namespace Ardalis.SmartEnum.UnitTests
 {
     using System;
     using FluentAssertions;
     using Xunit;
+    using Ardalis.SmartEnum.UnitTests.TestData;
 
     public class SmartEnumCompareTo
     {

--- a/test/SmartEnum.UnitTests/SmartEnumEquals.cs
+++ b/test/SmartEnum.UnitTests/SmartEnumEquals.cs
@@ -3,6 +3,7 @@ namespace Ardalis.SmartEnum.UnitTests
     using System;
     using FluentAssertions;
     using Xunit;
+    using Ardalis.SmartEnum.UnitTests.TestData;
 
     public class SmartEnumEquals
     {

--- a/test/SmartEnum.UnitTests/SmartEnumExplicitConversion.cs
+++ b/test/SmartEnum.UnitTests/SmartEnumExplicitConversion.cs
@@ -2,6 +2,8 @@
 {
     using FluentAssertions;
     using Xunit;
+    using Ardalis.SmartEnum.UnitTests.TestData;
+
 
     public class SmartEnumExplicitConversion
     {

--- a/test/SmartEnum.UnitTests/SmartEnumExtensionsTests.cs
+++ b/test/SmartEnum.UnitTests/SmartEnumExtensionsTests.cs
@@ -3,6 +3,7 @@ namespace Ardalis.SmartEnum.UnitTests
     using System;
     using FluentAssertions;
     using Xunit;
+    using Ardalis.SmartEnum.UnitTests.TestData;
 
     public class SmartEnumExtensionsTests
     {

--- a/test/SmartEnum.UnitTests/SmartEnumFromName.cs
+++ b/test/SmartEnum.UnitTests/SmartEnumFromName.cs
@@ -3,7 +3,8 @@
     using System;
     using FluentAssertions;
     using Xunit;
-
+    using Ardalis.SmartEnum.UnitTests.TestData;
+    
     public class SmartEnumFromName
     {
         [Fact]
@@ -49,7 +50,6 @@
 
             action.Should()
             .ThrowExactly<ArgumentException>()
-            .WithMessage($"Argument cannot be null or empty.{Environment.NewLine}Parameter name: name")
             .Which.ParamName.Should().Be("name");
         }
 
@@ -60,7 +60,6 @@
 
             action.Should()
             .ThrowExactly<ArgumentException>()
-            .WithMessage($"Argument cannot be null or empty.{Environment.NewLine}Parameter name: name")
             .Which.ParamName.Should().Be("name");
         }
 

--- a/test/SmartEnum.UnitTests/SmartEnumFromValue.cs
+++ b/test/SmartEnum.UnitTests/SmartEnumFromValue.cs
@@ -3,6 +3,7 @@
     using System;
     using FluentAssertions;
     using Xunit;
+    using Ardalis.SmartEnum.UnitTests.TestData;
 
     public class SmartEnumFromValue
     {

--- a/test/SmartEnum.UnitTests/SmartEnumImplicitValueConversion.cs
+++ b/test/SmartEnum.UnitTests/SmartEnumImplicitValueConversion.cs
@@ -2,6 +2,7 @@
 {
     using FluentAssertions;
     using Xunit;
+    using Ardalis.SmartEnum.UnitTests.TestData;
 
     public class SmartEnumImplicitValueConversion
     {

--- a/test/SmartEnum.UnitTests/SmartEnumList.cs
+++ b/test/SmartEnum.UnitTests/SmartEnumList.cs
@@ -2,6 +2,7 @@
 {
     using FluentAssertions;
     using Xunit;
+    using Ardalis.SmartEnum.UnitTests.TestData;
 
     public class SmartEnumList
     {
@@ -22,7 +23,38 @@
         {
             var result = TestBaseEnumWithDerivedValues.List;
 
-            result.Should().BeEquivalentTo(DerivedTestEnumWithValues1.A, DerivedTestEnumWithValues1.B, DerivedTestEnumWithValues2.C, DerivedTestEnumWithValues2.D);
+            result.Should().BeEquivalentTo(
+                DerivedTestEnumWithValues1.A,
+                DerivedTestEnumWithValues1.B,
+                DerivedTestEnumWithValues2.C,
+                DerivedTestEnumWithValues2.D);
+        }
+        
+        [Fact]
+        public void ReturnsAllBaseAndDerivedSmartEnumsFromMultipleAssemblies()
+        {
+            SmartEnumOptions.Add<AnotherEnumBase>(
+                typeof(AnotherEnumBase).Assembly,
+                typeof(AnotherEnumDerived3).Assembly);
+            
+            var result = AnotherEnumBase.List;
+
+            result.Should().BeEquivalentTo(
+                AnotherEnumDerived1.A,
+                AnotherEnumDerived1.B,
+                AnotherEnumDerived2.C,
+                AnotherEnumDerived2.D,
+                AnotherEnumDerived3.F,
+                AnotherEnumDerived3.G);
+        }
+        
+        
+        public class AnotherEnumDerived3 : AnotherEnumBase
+        {
+            public static readonly AnotherEnumDerived3 F = new AnotherEnumDerived3(nameof(F), 5);
+            public static readonly AnotherEnumDerived3 G = new AnotherEnumDerived3(nameof(G), 6);
+
+            private AnotherEnumDerived3(string name, int value) : base(name, value) { }
         }
     }
 }

--- a/test/SmartEnum.UnitTests/SmartEnumStringEquals.cs
+++ b/test/SmartEnum.UnitTests/SmartEnumStringEquals.cs
@@ -3,6 +3,7 @@ namespace Ardalis.SmartEnum.UnitTests
     using System;
     using FluentAssertions;
     using Xunit;
+    using Ardalis.SmartEnum.UnitTests.TestData;
 
     public class SmartEnumStringEquals
     {

--- a/test/SmartEnum.UnitTests/SmartEnumStringFromValue.cs
+++ b/test/SmartEnum.UnitTests/SmartEnumStringFromValue.cs
@@ -3,6 +3,7 @@
     using FluentAssertions;
     using System;
     using Xunit;
+    using Ardalis.SmartEnum.UnitTests.TestData;
 
     public class SmartEnumStringFromValue
     {

--- a/test/SmartEnum.UnitTests/SmartEnumToString.cs
+++ b/test/SmartEnum.UnitTests/SmartEnumToString.cs
@@ -2,6 +2,7 @@
 {
     using FluentAssertions;
     using Xunit;
+    using Ardalis.SmartEnum.UnitTests.TestData;
 
     public class SmartEnumToString
     {

--- a/test/SmartEnum.UnitTests/SmartEnumTryFromName.cs
+++ b/test/SmartEnum.UnitTests/SmartEnumTryFromName.cs
@@ -3,6 +3,7 @@ namespace Ardalis.SmartEnum.UnitTests
     using System;
     using FluentAssertions;
     using Xunit;
+    using Ardalis.SmartEnum.UnitTests.TestData;
 
     public class SmartEnumTryFromName
     {

--- a/test/SmartEnum.UnitTests/SmartEnumWhenThen.cs
+++ b/test/SmartEnum.UnitTests/SmartEnumWhenThen.cs
@@ -3,6 +3,7 @@
     using FluentAssertions;
     using System.Collections.Generic;
     using Xunit;
+    using Ardalis.SmartEnum.UnitTests.TestData;
 
     public class SmartEnumWhenThen
     {

--- a/test/SmartEnumTests.ruleset
+++ b/test/SmartEnumTests.ruleset
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Rules for SmartEnums Tests" Description="Code analysis rules for SmartEnum Tests" ToolsVersion="15.0">
+  <Rules AnalyzerId="xunit.analyzers" RuleNamespace="xunit.analyzers">
+    <!-- 
+      This code is produced when theory parameters that are unused. Normally, this is a warning which causes our build to fail.
+    -->
+
+  </Rules>
+</RuleSet>


### PR DESCRIPTION
This is how one could "register" all derived types of a given base enum laying in multiple assemblies (see #93).
Contains breaking change in how different derived classes with same values are handled (see #99).