### PR TITLE
fix (BuildWarning): Update obsoleted method calls in Benchmarks Config

### DIFF
--- a/benchmarks/SmartEnum.Benchmarks/Config.cs
+++ b/benchmarks/SmartEnum.Benchmarks/Config.cs
@@ -9,9 +9,9 @@ namespace Ardalis.SmartEnum.Benchmarks
     {
         public Config()
         {
-            Add(Job.Default);
-            Add(MemoryDiagnoser.Default);
-            Add(new TagColumn("Library", name => name.Split('_')[0]));
+            AddJob(Job.Default);
+            AddDiagnoser(MemoryDiagnoser.Default);
+            AddColumn(new TagColumn("Library", name => name.Split('_')[0]));
         }
     }
 }


### PR DESCRIPTION
Replace obsolete method calls in Benchmark test to remove build warnings.