### PR TITLE
Update packages in SmartEnum.SystemTextJson

### DIFF
--- a/src/SmartEnum.SystemTextJson/SmartEnum.SystemTextJson.csproj
+++ b/src/SmartEnum.SystemTextJson/SmartEnum.SystemTextJson.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;</TargetFrameworks>
     <PackageId>Ardalis.SmartEnum.SystemTextJson</PackageId>
@@ -17,10 +17,10 @@
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Ardalis.SmartEnum" Version="1.0.11" />
+    <PackageReference Include="Ardalis.SmartEnum" Version="2.0.1" />
     <PackageReference Include="System.Text.Json" Version="5.0.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="All" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.17.0.26580" PrivateAssets="All" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.20.0.28934" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <None Include="icon.png" Pack="true" Visible="false" PackagePath="" />


### PR DESCRIPTION
Hi @ardalis!

If you have two projects **A** and **B**, and **B** has a reference to **A**.
And **A** is using the SmartEnum 2.0.1. and **B** is using the SmartEnum.SystemText.Json 1.0.0., you will get an error:

```
An unhandled exception has occurred while executing the request.
System.IO.FileLoadException: Could not load file or assembly 'Ardalis.SmartEnum, Version=1.0.11.0, Culture=neutral, PublicKeyToken=null'. The located assembly's manifest definition does not match the assembly reference. (0x80131040)
File name: 'Ardalis.SmartEnum, Version=1.0.11.0, Culture=neutral, PublicKeyToken=null'
```

If you downgrade the SmartEnum to 1.0.11. in **A**, the project will work again.

So this PR updates the package references to the latest.