### PR TITLE
Upgraded to Net480 and corrected SmartEnum package reference

### DIFF
--- a/src/SmartEnum.AutoFixture/SmartEnum.AutoFixture.csproj
+++ b/src/SmartEnum.AutoFixture/SmartEnum.AutoFixture.csproj
@@ -1,14 +1,14 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net480</TargetFrameworks>
     <PackageId>Ardalis.SmartEnum.AutoFixture</PackageId>
     <Title>Ardalis.SmartEnum.AutoFixture</Title>
     <Company>Ardalis.com</Company>
     <Summary>AutoFixture support for Ardalis.SmartEnum.</Summary>
     <PackageTags>enum;smartenum;netstandard2.0;autofixture</PackageTags>
-    <PackageReleaseNotes>Net452 Added</PackageReleaseNotes>
+    <PackageReleaseNotes>Upgraded to Net480 and corrected SmartEnum package reference</PackageReleaseNotes>
     <PackageIcon>icon.png</PackageIcon>
-    <Version>1.0.3</Version>
+    <Version>1.0.31</Version>
     <AssemblyName>Ardalis.SmartEnum.AutoFixture</AssemblyName>
     <RootNamespace>Ardalis.SmartEnum.AutoFixture</RootNamespace>
     <Features>strict</Features>
@@ -18,12 +18,12 @@
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Ardalis.SmartEnum" Version="1.0.11" />
+    <PackageReference Include="Ardalis.SmartEnum" Version="2.0.1" />
     <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="All" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="8.23.0.32424" PrivateAssets="All" />
   </ItemGroup>
-    <ItemGroup>
+  <ItemGroup>
     <None Include="icon.png" Pack="true" Visible="false" PackagePath="" />
   </ItemGroup>
 </Project>

--- a/src/SmartEnum.JsonNet/SmartEnum.JsonNet.csproj
+++ b/src/SmartEnum.JsonNet/SmartEnum.JsonNet.csproj
@@ -1,14 +1,14 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net480</TargetFrameworks>
     <PackageId>Ardalis.SmartEnum.JsonNet</PackageId>
     <Title>Ardalis.SmartEnum.JsonNet</Title>
     <Company>Ardalis.com</Company>
     <Summary>Json.NET (de)serialization support for Ardalis.SmartEnum.</Summary>
     <PackageTags>enum;smartenum;netstandard2.0;json;json.net;converter</PackageTags>
-    <PackageReleaseNotes>Net452 Added</PackageReleaseNotes>
+    <PackageReleaseNotes>Upgraded to Net480 and corrected SmartEnum package reference</PackageReleaseNotes>
     <PackageIcon>icon.png</PackageIcon>
-    <Version>1.0.3</Version>
+    <Version>1.0.31</Version>
     <AssemblyName>Ardalis.SmartEnum.JsonNet</AssemblyName>
     <RootNamespace>Ardalis.SmartEnum.JsonNet</RootNamespace>
     <Features>strict</Features>
@@ -18,7 +18,7 @@
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Ardalis.SmartEnum" Version="1.0.11" />
+    <PackageReference Include="Ardalis.SmartEnum" Version="2.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="All" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="8.23.0.32424" PrivateAssets="All" />

--- a/src/SmartEnum.MessagePack/SmartEnum.MessagePack.csproj
+++ b/src/SmartEnum.MessagePack/SmartEnum.MessagePack.csproj
@@ -1,14 +1,14 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net480</TargetFrameworks>
     <PackageId>Ardalis.SmartEnum.MessagePack</PackageId>
     <Title>Ardalis.SmartEnum.MessagePack</Title>
     <Company>Ardalis.com</Company>
     <Summary>MessagePack (de)serialization support for Ardalis.SmartEnum.</Summary>
     <PackageTags>enum;smartenum;netstandard2.0;messagepack;resolver</PackageTags>
-    <PackageReleaseNotes>Net452 Added</PackageReleaseNotes>
+    <PackageReleaseNotes>Upgraded to Net480 and corrected SmartEnum package reference</PackageReleaseNotes>
     <PackageIcon>icon.png</PackageIcon>
-    <Version>1.0.3</Version>
+    <Version>1.0.31</Version>
     <AssemblyName>Ardalis.SmartEnum.MessagePack</AssemblyName>
     <RootNamespace>Ardalis.SmartEnum.MessagePack</RootNamespace>
     <Features>strict</Features>
@@ -18,7 +18,7 @@
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Ardalis.SmartEnum" Version="1.0.11" />
+    <PackageReference Include="Ardalis.SmartEnum" Version="2.0.1" />
     <PackageReference Include="MessagePack" Version="1.9.11" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="All" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="8.23.0.32424" PrivateAssets="All" />

--- a/src/SmartEnum.ProtoBufNet/SmartEnum.ProtoBufNet.csproj
+++ b/src/SmartEnum.ProtoBufNet/SmartEnum.ProtoBufNet.csproj
@@ -1,14 +1,14 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net480</TargetFrameworks>
     <PackageId>Ardalis.SmartEnum.ProtoBufNet</PackageId>
     <Title>Ardalis.SmartEnum.ProtoBufNet</Title>
     <Company>Ardalis.com</Company>
     <Summary>protobuf-net (de)serialization support for Ardalis.SmartEnum.</Summary>
     <PackageTags>enum;smartenum;netstandard2.0;protobuf;protobufnet;surrogate</PackageTags>
-    <PackageReleaseNotes>Net452 Added</PackageReleaseNotes>
+    <PackageReleaseNotes>Upgraded to Net480 and corrected SmartEnum package reference</PackageReleaseNotes>
     <PackageIcon>icon.png</PackageIcon>
-    <Version>1.0.3</Version>
+    <Version>1.0.31</Version>
     <AssemblyName>Ardalis.SmartEnum.ProtoBufNet</AssemblyName>
     <RootNamespace>Ardalis.SmartEnum.ProtoBufNet</RootNamespace>
     <Features>strict</Features>
@@ -18,7 +18,7 @@
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Ardalis.SmartEnum" Version="1.0.11" />
+    <PackageReference Include="Ardalis.SmartEnum" Version="2.0.1" />
     <PackageReference Include="protobuf-net" Version="2.4.6" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="All" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="8.23.0.32424" PrivateAssets="All" />

--- a/src/SmartEnum.SystemTextJson/SmartEnum.SystemTextJson.csproj
+++ b/src/SmartEnum.SystemTextJson/SmartEnum.SystemTextJson.csproj
@@ -7,7 +7,7 @@
     <Summary>System.Text.Json (de)serialization support for Ardalis.SmartEnum.</Summary>
     <PackageTags>enum;smartenum;netstandard2.0;json;system.text.json;converter</PackageTags>
     <PackageIcon>icon.png</PackageIcon>
-    <Version>1.0.0</Version>
+    <Version>1.0.01</Version>
     <AssemblyName>Ardalis.SmartEnum.SystemTextJson</AssemblyName>
     <RootNamespace>Ardalis.SmartEnum.SystemTextJson</RootNamespace>
     <Features>strict</Features>

--- a/src/SmartEnum.Utf8Json/SmartEnum.Utf8Json.csproj
+++ b/src/SmartEnum.Utf8Json/SmartEnum.Utf8Json.csproj
@@ -1,14 +1,14 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net480</TargetFrameworks>
     <PackageId>Ardalis.SmartEnum.Utf8Json</PackageId>
     <Title>Ardalis.SmartEnum.Utf8Json</Title>
     <Company>Ardalis.com</Company>
     <Summary>Utf8Json (de)serialization support for Ardalis.SmartEnum.</Summary>
     <PackageTags>enum;smartenum;netstandard2.0;json;utf8json;resolver</PackageTags>
-    <PackageReleaseNotes>Net452 Added</PackageReleaseNotes>
+    <PackageReleaseNotes>Upgraded to Net480</PackageReleaseNotes>
     <PackageIcon>icon.png</PackageIcon>
-    <Version>1.0.3</Version>
+    <Version>1.0.31</Version>
     <AssemblyName>Ardalis.SmartEnum.Utf8Json</AssemblyName>
     <RootNamespace>Ardalis.SmartEnum.Utf8Json</RootNamespace>
     <Features>strict</Features>
@@ -18,7 +18,7 @@
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Ardalis.SmartEnum" Version="1.0.11" />
+    <PackageReference Include="Ardalis.SmartEnum" Version="2.0.1" />
     <PackageReference Include="Utf8Json" Version="1.3.7" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="All" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="8.23.0.32424" PrivateAssets="All" />

--- a/src/SmartEnum/SmartEnum.csproj
+++ b/src/SmartEnum/SmartEnum.csproj
@@ -18,6 +18,7 @@
     <AssemblyName>Ardalis.SmartEnum</AssemblyName>
     <Features>strict</Features>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
@@ -33,7 +34,7 @@
     <PackageReference Include="SonarAnalyzer.CSharp" Version="8.23.0.32424" PrivateAssets="All" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net480' ">
     <PackageReference Include="System.Linq" Version="4.3.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Hello,

These package reference updates are in reference to issue #113 . It wasn't too difficult to see that it was referencing the old SmartEnum version in the sub-packages.

In particular, I was using Ardalis.SmartEnum.JsonNet so I started there. When the SmartEnum version is updated in Ardalis.SmartEnum.JsonNet, it gives a compatibility issue with the .NET Framework version 4.5.2, which is why it is updated to the latest .NET Framework. I went ahead and updated each project to have the same versions.

Following this, I no longer received any errors when using the latest versions of SmartEnum.

First time doing a pull request to an open source project, so let me know if I did anything incorrectly...

- Nevin