### PR TITLE
fix SmartEnum implicit NullReferenceException

### DIFF
--- a/src/SmartEnum/SmartEnum.cs
+++ b/src/SmartEnum/SmartEnum.cs
@@ -356,7 +356,9 @@ namespace Ardalis.SmartEnum
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static implicit operator TValue(SmartEnum<TEnum, TValue> smartEnum) =>
-            smartEnum._value;
+            smartEnum is not null
+                ? smartEnum._value 
+                : default;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static explicit operator SmartEnum<TEnum, TValue>(TValue value) =>


### PR DESCRIPTION
Implicit not throw Exception
[CA1065](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1065)

Or remove implicit becose `default` for struct can return invalid value.