### PR TITLE
feat: Add Targets for NET6 and NetStandard 2.1 | Bump packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,25 @@
+name: Build-Test
+
+on:
+  push:
+    branches: [ "*" ]
+  pull_request:
+    branches: [ "*" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 7.0.x
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --no-restore
+    - name: Test
+      run: dotnet test --no-build --verbosity normal

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,27 +3,36 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="AutoFixture" Version="4.17.0" />
-    <PackageVersion Include="BenchmarkDotNet" Version="0.13.4" />
+    <PackageVersion Include="AutoFixture" Version="4.18.0" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.13.5" />
     <PackageVersion Include="Constant" Version="2.0.4" />
-    <PackageVersion Include="coverlet.collector" Version="3.2.0" />
-    <PackageVersion Include="coverlet.msbuild" Version="3.2.0" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageVersion>
+    <PackageVersion Include="coverlet.msbuild" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageVersion>
     <PackageVersion Include="Dapper" Version="2.0.123" />
     <PackageVersion Include="Enums.NET" Version="4.0.1" />
-    <PackageVersion Include="FluentAssertions" Version="6.9.0" />
-    <PackageVersion Include="MessagePack" Version="2.4.59" />
+    <PackageVersion Include="FluentAssertions" Version="6.11.0" />
+    <PackageVersion Include="MessagePack" Version="2.5.108" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
-    <PackageVersion Include="Microsoft.Data.Sqlite" Version="7.0.2" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="7.0.2" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.2" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.2" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="7.0.5" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="7.0.5" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageVersion>
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.5" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="Moq" Version="4.18.4" />
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.2" />
-    <PackageVersion Include="protobuf-net" Version="3.1.26" />
-    <PackageVersion Include="SonarAnalyzer.CSharp" Version="8.51.0.59060" />
-    <PackageVersion Include="System.Text.Json" Version="7.0.1" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageVersion Include="protobuf-net" Version="3.2.26" />
+    <PackageVersion Include="SonarAnalyzer.CSharp" Version="8.56.0.67649" />
+    <PackageVersion Include="System.Text.Json" Version="7.0.2" />
     <PackageVersion Include="Utf8Json" Version="1.3.7" />
     <PackageVersion Include="xunit" Version="2.4.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />

--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ Install-Package Ardalis.SmartEnum.Dapper
 
 ## Version
 
-The latest version of the package supports .NET 7. If you don't need or aren't yet ready to move to .NET 7 or later, you should install the previous stable version, [Ardalis.SmartEnum 2.1](https://www.nuget.org/packages/Ardalis.SmartEnum/2.1.0).
+The latest version of the package multi-targets `.NET7`, `.NET6` and `.NetStandard2.1` (Excluding the EFCore package which is incompatbile with .NetStandard 2.1). 
+If you don't need or aren't yet ready to move to .NET 7 or later, you should install the previous stable version, [Ardalis.SmartEnum 2.1](https://www.nuget.org/packages/Ardalis.SmartEnum/2.1.0).
 
 Example package manager command:
 

--- a/SmartEnum.sln
+++ b/SmartEnum.sln
@@ -11,13 +11,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution", "Solution", "{E4
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
 		.gitignore = .gitignore
-		azure-pipelines.yml = azure-pipelines.yml
 		Directory.Build.props = Directory.Build.props
 		Directory.Packages.props = Directory.Packages.props
 		LICENSE = LICENSE
 		nuget.txt = nuget.txt
 		README.md = README.md
-		SmartEnumTests.ruleset = SmartEnumTests.ruleset
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SmartEnum.Benchmarks", "benchmarks\SmartEnum.Benchmarks\SmartEnum.Benchmarks.csproj", "{0F0C288D-39BA-4E83-A7FE-3B90D7CF250A}"

--- a/benchmarks/SmartEnum.Benchmarks/SmartEnum.Benchmarks.csproj
+++ b/benchmarks/SmartEnum.Benchmarks/SmartEnum.Benchmarks.csproj
@@ -6,9 +6,9 @@
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet"  />
-    <PackageReference Include="Constant"  />
-    <PackageReference Include="Enums.NET"  />
+    <PackageReference Include="BenchmarkDotNet" />
+    <PackageReference Include="Constant" />
+    <PackageReference Include="Enums.NET" />
     <ProjectReference Include="..\..\src\SmartEnum.MessagePack\SmartEnum.MessagePack.csproj" />
     <ProjectReference Include="..\..\src\SmartEnum\SmartEnum.csproj" />
     <ProjectReference Include="..\..\src\SmartEnum.JsonNet\SmartEnum.JsonNet.csproj" />

--- a/src/SmartEnum.AutoFixture/SmartEnum.AutoFixture.csproj
+++ b/src/SmartEnum.AutoFixture/SmartEnum.AutoFixture.csproj
@@ -10,6 +10,8 @@
 		<PackageReleaseNotes>Updating to net7</PackageReleaseNotes>
 		<AssemblyName>Ardalis.SmartEnum.AutoFixture</AssemblyName>
 		<RootNamespace>Ardalis.SmartEnum.AutoFixture</RootNamespace>
+		<TargetFrameworks>net7.0;net6.0;netstandard2.1</TargetFrameworks>
+		<TargetFramework />
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
 		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>

--- a/src/SmartEnum.Dapper/SmartEnum.Dapper.csproj
+++ b/src/SmartEnum.Dapper/SmartEnum.Dapper.csproj
@@ -7,9 +7,12 @@
 		<PackageTags>enum;smartenum;dapper;ardalis</PackageTags>
 		<PackageReleaseNotes>Updating to net7.</PackageReleaseNotes>
 		<PackageIcon>icon.png</PackageIcon>
+		<LangVersion>11.0</LangVersion>
 		<AssemblyName>Ardalis.SmartEnum.Dapper</AssemblyName>
 		<RootNamespace>Ardalis.SmartEnum.Dapper</RootNamespace>
 		<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+		<TargetFrameworks>net7.0;net6.0;netstandard2.1</TargetFrameworks>
+		<TargetFramework />
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
 		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>

--- a/src/SmartEnum.EFCore/SmartEnum.EFCore.csproj
+++ b/src/SmartEnum.EFCore/SmartEnum.EFCore.csproj
@@ -11,6 +11,7 @@
 		<AssemblyName>Ardalis.SmartEnum.EFCore</AssemblyName>
 		<RootNamespace>Ardalis.SmartEnum.EFCore</RootNamespace>
 		<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+		<TargetFrameworks>net6.0;net7.0</TargetFrameworks>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
 		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>

--- a/src/SmartEnum.JsonNet/SmartEnum.JsonNet.csproj
+++ b/src/SmartEnum.JsonNet/SmartEnum.JsonNet.csproj
@@ -9,12 +9,14 @@
 		<PackageIcon>icon.png</PackageIcon>
 		<AssemblyName>Ardalis.SmartEnum.JsonNet</AssemblyName>
 		<RootNamespace>Ardalis.SmartEnum.JsonNet</RootNamespace>
+		<TargetFrameworks>net7.0;net6.0;netstandard2.1</TargetFrameworks>
+		<TargetFramework />
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
 		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Newtonsoft.Json"  />
+		<PackageReference Include="Newtonsoft.Json" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
 		<PackageReference Include="SonarAnalyzer.CSharp" PrivateAssets="All" />
 	</ItemGroup>

--- a/src/SmartEnum.MessagePack/SmartEnum.MessagePack.csproj
+++ b/src/SmartEnum.MessagePack/SmartEnum.MessagePack.csproj
@@ -9,6 +9,8 @@
 		<PackageIcon>icon.png</PackageIcon>
 		<AssemblyName>Ardalis.SmartEnum.MessagePack</AssemblyName>
 		<RootNamespace>Ardalis.SmartEnum.MessagePack</RootNamespace>
+		<TargetFrameworks>net7.0;net6.0;netstandard2.1</TargetFrameworks>
+		<TargetFramework />
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
 		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>

--- a/src/SmartEnum.ModelBinding/SmartEnum.ModelBinding.csproj
+++ b/src/SmartEnum.ModelBinding/SmartEnum.ModelBinding.csproj
@@ -9,15 +9,17 @@
         <PackageIcon>icon.png</PackageIcon>
         <PackageReleaseNotes>Updating to net7.</PackageReleaseNotes>
         <AssemblyName>Ardalis.SmartEnum.ModelBinding</AssemblyName>
+        <TargetFrameworks>net7.0;net6.0;netstandard2.1</TargetFrameworks>
+        <TargetFramework />
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Core"/>
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" />
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="..\SmartEnum\SmartEnum.csproj"/>
+        <ProjectReference Include="..\SmartEnum\SmartEnum.csproj" />
     </ItemGroup>
     <ItemGroup>
-        <None Include="$(SolutionDir)img\icon.png" Pack="true" Visible="false" PackagePath=""/>
+        <None Include="$(SolutionDir)img\icon.png" Pack="true" Visible="false" PackagePath="" />
     </ItemGroup>
 </Project>

--- a/src/SmartEnum.ProtoBufNet/SmartEnum.ProtoBufNet.csproj
+++ b/src/SmartEnum.ProtoBufNet/SmartEnum.ProtoBufNet.csproj
@@ -9,6 +9,8 @@
 		<PackageIcon>icon.png</PackageIcon>
 		<AssemblyName>Ardalis.SmartEnum.ProtoBufNet</AssemblyName>
 		<RootNamespace>Ardalis.SmartEnum.ProtoBufNet</RootNamespace>
+		<TargetFrameworks>net7.0;net6.0;netstandard2.1</TargetFrameworks>
+		<TargetFramework />
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
 		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>

--- a/src/SmartEnum.SystemTextJson/SmartEnum.SystemTextJson.csproj
+++ b/src/SmartEnum.SystemTextJson/SmartEnum.SystemTextJson.csproj
@@ -10,6 +10,8 @@
 		<PackageReleaseNotes>Updating to net7.</PackageReleaseNotes>
 		<AssemblyName>Ardalis.SmartEnum.SystemTextJson</AssemblyName>
 		<RootNamespace>Ardalis.SmartEnum.SystemTextJson</RootNamespace>
+		<TargetFrameworks>net7.0;net6.0;netstandard2.1</TargetFrameworks>
+		<TargetFramework />
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
 		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>

--- a/src/SmartEnum.Utf8Json/SmartEnum.Utf8Json.csproj
+++ b/src/SmartEnum.Utf8Json/SmartEnum.Utf8Json.csproj
@@ -9,6 +9,8 @@
 		<PackageIcon>icon.png</PackageIcon>
 		<AssemblyName>Ardalis.SmartEnum.Utf8Json</AssemblyName>
 		<RootNamespace>Ardalis.SmartEnum.Utf8Json</RootNamespace>
+		<TargetFrameworks>net7.0;net6.0;netstandard2.1</TargetFrameworks>
+		<TargetFramework />
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
 		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>

--- a/src/SmartEnum/SmartEnum.cs
+++ b/src/SmartEnum/SmartEnum.cs
@@ -356,7 +356,7 @@ namespace Ardalis.SmartEnum
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static implicit operator TValue(SmartEnum<TEnum, TValue> smartEnum) =>
-            smartEnum is not null
+            smartEnum != null
                 ? smartEnum._value 
                 : default;
 

--- a/src/SmartEnum/SmartEnum.csproj
+++ b/src/SmartEnum/SmartEnum.csproj
@@ -10,6 +10,8 @@
 		<PackageReleaseNotes>Updating to net7.</PackageReleaseNotes>
 		<AssemblyName>Ardalis.SmartEnum</AssemblyName>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<TargetFrameworks>net6.0;net7.0;netstandard2.1</TargetFrameworks>
+		<TargetFramework />
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)'=='Debug'">

--- a/test/SmartEnum.AutoFixture.UnitTests/SmartEnum.AutoFixture.UnitTests.csproj
+++ b/test/SmartEnum.AutoFixture.UnitTests/SmartEnum.AutoFixture.UnitTests.csproj
@@ -4,6 +4,8 @@
     <IsPackable>false</IsPackable>
     <LangVersion>7.3</LangVersion>
     <Features>strict</Features>
+    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
+    <TargetFramework />
   </PropertyGroup>
   <ItemGroup>
     
@@ -16,7 +18,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" >
+    <PackageReference Include="coverlet.msbuild">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/test/SmartEnum.Dapper.IntegrationTests/SmartEnum.Dapper.IntegrationTests.csproj
+++ b/test/SmartEnum.Dapper.IntegrationTests/SmartEnum.Dapper.IntegrationTests.csproj
@@ -8,7 +8,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" />
 		<PackageReference Include="xunit" />
-		<PackageReference Include="xunit.runner.visualstudio" >
+		<PackageReference Include="xunit.runner.visualstudio">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>

--- a/test/SmartEnum.Dapper.UnitTests/SmartEnum.Dapper.UnitTests.csproj
+++ b/test/SmartEnum.Dapper.UnitTests/SmartEnum.Dapper.UnitTests.csproj
@@ -2,13 +2,15 @@
 	<PropertyGroup>
 		<IsPackable>false</IsPackable>
 		<RootNamespace>Ardalis.SmartEnum.Dapper.UnitTests</RootNamespace>
+		<TargetFrameworks>net7.0;net6.0</TargetFrameworks>
+		<TargetFramework />
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk"  />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
 		<PackageReference Include="Moq" />
 		<PackageReference Include="xunit" />
-		<PackageReference Include="xunit.runner.visualstudio" >
+		<PackageReference Include="xunit.runner.visualstudio">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>

--- a/test/SmartEnum.JsonNet.UnitTests/SmartEnum.JsonNet.UnitTests.csproj
+++ b/test/SmartEnum.JsonNet.UnitTests/SmartEnum.JsonNet.UnitTests.csproj
@@ -3,6 +3,8 @@
     <IsPackable>false</IsPackable>
     <LangVersion>7.3</LangVersion>
     <Features>strict</Features>
+    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
+    <TargetFramework />
   </PropertyGroup>
 
   <ItemGroup>
@@ -10,11 +12,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" >
+    <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" >
+    <PackageReference Include="coverlet.msbuild">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/test/SmartEnum.MessagePack.UnitTests/SmartEnum.MessagePack.UnitTests.csproj
+++ b/test/SmartEnum.MessagePack.UnitTests/SmartEnum.MessagePack.UnitTests.csproj
@@ -1,8 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8</LangVersion>
     <Features>strict</Features>
+    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
+    <TargetFramework />
   </PropertyGroup>
   <ItemGroup>
     

--- a/test/SmartEnum.ProtoBufNet.UnitTests/SmartEnum.ProtoBufNet.UnitTests.csproj
+++ b/test/SmartEnum.ProtoBufNet.UnitTests/SmartEnum.ProtoBufNet.UnitTests.csproj
@@ -1,8 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8</LangVersion>
     <Features>strict</Features>
+    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
+    <TargetFramework />
   </PropertyGroup>
   <ItemGroup>
     

--- a/test/SmartEnum.SystemTextJson.UnitTests/SmartEnum.SystemTextJson.UnitTests.csproj
+++ b/test/SmartEnum.SystemTextJson.UnitTests/SmartEnum.SystemTextJson.UnitTests.csproj
@@ -1,15 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
+    <TargetFramework />
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\SmartEnum.SystemTextJson\SmartEnum.SystemTextJson.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" >
+    <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" >
+    <PackageReference Include="coverlet.msbuild">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/test/SmartEnum.UnitTests/SmartEnum.UnitTests.csproj
+++ b/test/SmartEnum.UnitTests/SmartEnum.UnitTests.csproj
@@ -3,6 +3,8 @@
     <IsPackable>false</IsPackable>
     <LangVersion>7.3</LangVersion>
     <Features>strict</Features>
+    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
+    <TargetFramework />
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\SmartEnum\SmartEnum.csproj" />

--- a/test/SmartEnum.Utf8Json.UnitTests/SmartEnum.Utf8Json.UnitTests.csproj
+++ b/test/SmartEnum.Utf8Json.UnitTests/SmartEnum.Utf8Json.UnitTests.csproj
@@ -1,26 +1,28 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8</LangVersion>
     <Features>strict</Features>
+    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
+    <TargetFramework />
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\SmartEnum.Utf8Json\SmartEnum.Utf8Json.csproj" />
     <ProjectReference Include="..\..\src\SmartEnum\SmartEnum.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" >
+    <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" >
+    <PackageReference Include="coverlet.msbuild">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
-    <PackageReference Include="xunit.runner.visualstudio" >
+    <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/test/SmartFlagEnum.UnitTests/SmartFlagEnum.UnitTests.csproj
+++ b/test/SmartFlagEnum.UnitTests/SmartFlagEnum.UnitTests.csproj
@@ -2,14 +2,16 @@
 
 	<PropertyGroup>
 		<IsPackable>false</IsPackable>
+		<TargetFrameworks>net7.0;net6.0</TargetFrameworks>
+		<TargetFramework />
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk"  />
-		<PackageReference Include="xunit"  />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="xunit" />
 		<PackageReference Include="xunit.runner.visualstudio" />
 		<PackageReference Include="coverlet.collector" />
-		<PackageReference Include="coverlet.msbuild" >
+		<PackageReference Include="coverlet.msbuild">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>


### PR DESCRIPTION
- Add back support for `.net6` (current LTS)  and `.NetStandard 2.1`
- Bump packages
- Add basic build/test workflow.

**NOTE**: efCore package excludes.NetStandard 2.1 as it is not compatible with EFCore 7 assemblies.

Resolves #363
