### PR TITLE
#402 Added support for case insensitive enums of strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
   * [Json.NET support](#jsonnet-support)
   * [Dapper support](#dapper-support)
   * [DapperSmartEnum](#dappersmartenum)
+  * [Case Insensitive String Enum](#case-insensitive-string-enum)
   * [Examples in the Real World](#examples-in-the-real-world)
   * [References](#references)
 
@@ -806,6 +807,28 @@ should have their `DbType` property set to the specified value. Use `DoNotSetDbT
 `[DoNotSetDbType]`) to specify that parameters should not have their `DbType` property set. Use
 `IgnoreCaseAttribute` (e.g. `[IgnoreCase]`) when inheriting from `DapperSmartEnumByName` to specify
 that database values do not need to match the case of a SmartEnum Name.
+
+### Case Insensitive String Enum
+
+When creating enums of strings, the default behaviour of SmartEnum is to compare the strings with a case sensitive comparer.
+It is possible to specify a different equality comparer for the enum values, for example a case insensitive one:
+
+```csharp
+[SmartEnumStringComparer(StringComparison.InvariantCultureIgnoreCase)]
+public class CaseInsensitiveEnum : SmartEnum<CaseInsensitiveEnum, string>
+{
+    protected CaseInsensitiveEnum(string name, string value) : base(name, value) { }
+
+    public static CaseInsensitiveEnum One = new CaseInsensitiveEnum("One", "one");
+    public static CaseInsensitiveEnum Two = new CaseInsensitiveEnum("Two", "two");
+}
+
+var e1 = CaseInsensitiveEnum.FromValue("ONE");
+var e2 = CaseInsensitiveEnum.FromValue("one");
+
+//e1 is equal to e2
+```
+
 
 ## Examples in the Real World
 

--- a/src/SmartEnum/SmartEnum.cs
+++ b/src/SmartEnum/SmartEnum.cs
@@ -1,5 +1,3 @@
-﻿using System.Runtime.InteropServices.ComTypes;
-
 namespace Ardalis.SmartEnum
 {
     using System;
@@ -52,7 +50,7 @@ namespace Ardalis.SmartEnum
             new Lazy<Dictionary<TValue, TEnum>>(() =>
             {
                 // multiple enums with same value are allowed but store only one per value
-                var dictionary = new Dictionary<TValue, TEnum>();
+                var dictionary = new Dictionary<TValue, TEnum>(GetValueComparer());
                 foreach (var item in _enumOptions.Value)
                 {
                     if (!dictionary.ContainsKey(item._value))
@@ -70,6 +68,12 @@ namespace Ardalis.SmartEnum
                 .SelectMany(t => t.GetFieldsOfType<TEnum>())
                 .OrderBy(t => t.Name)
                 .ToArray();
+        }
+
+        private static IEqualityComparer<TValue> GetValueComparer()
+        {
+            var comparer = typeof(TEnum).GetCustomAttribute<SmartEnumComparerAttribute<TValue>>();
+            return comparer?.Comparer;
         }
 
         /// <summary>

--- a/src/SmartEnum/SmartEnumComparerAttribute.cs
+++ b/src/SmartEnum/SmartEnumComparerAttribute.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+
+namespace Ardalis.SmartEnum
+{
+    /// <summary>
+    /// Base class for an <see cref="Attribute"/> to specify the <see cref="IEqualityComparer{T}"/> for a SmartEnum.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    [AttributeUsage(AttributeTargets.Class)]
+    public class SmartEnumComparerAttribute<T> : Attribute
+    {
+        private readonly IEqualityComparer<T> _comparer;
+
+        protected SmartEnumComparerAttribute(IEqualityComparer<T> comparer)
+        {
+            _comparer = comparer;
+        }
+
+        public IEqualityComparer<T> Comparer => _comparer;
+    }
+
+    /// <summary>
+    /// Attribute to apply to <see cref="SmartEnum{TEnum, string}"/> of type <see cref="string"/> to specify how to compare
+    /// the enum values
+    /// </summary>
+    public class SmartEnumStringComparerAttribute : SmartEnumComparerAttribute<string>
+    {
+        public SmartEnumStringComparerAttribute(StringComparison comparison)
+            : base(GetComparer(comparison))
+        {
+        }
+
+        private static IEqualityComparer<string> GetComparer(StringComparison comparison)
+        {
+            switch (comparison)
+            {
+                case StringComparison.Ordinal:
+                    return StringComparer.Ordinal;
+                case StringComparison.OrdinalIgnoreCase:
+                    return StringComparer.OrdinalIgnoreCase;
+                case StringComparison.CurrentCulture:
+                    return StringComparer.CurrentCulture;
+                case StringComparison.CurrentCultureIgnoreCase:
+                    return StringComparer.CurrentCultureIgnoreCase;
+                case StringComparison.InvariantCulture:
+                    return StringComparer.InvariantCulture;
+                case StringComparison.InvariantCultureIgnoreCase:
+                    return StringComparer.InvariantCultureIgnoreCase;
+            }
+
+            throw new ArgumentException($"StringComparison {comparison} is not supported", nameof(comparison));
+        }
+    }
+}

--- a/test/SmartEnum.UnitTests/SmartEnumComparerAttribute.cs
+++ b/test/SmartEnum.UnitTests/SmartEnumComparerAttribute.cs
@@ -1,9 +1,9 @@
-using FluentAssertions;
-using System;
-using Xunit;
-
 namespace Ardalis.SmartEnum.UnitTests
 {
+    using FluentAssertions;
+    using System;
+    using Xunit;
+
     public class SmartEnumComparerAttribute
     {
         public class VanillaStringEnum : SmartEnum<VanillaStringEnum, string>

--- a/test/SmartEnum.UnitTests/SmartEnumComparerAttribute.cs
+++ b/test/SmartEnum.UnitTests/SmartEnumComparerAttribute.cs
@@ -1,0 +1,95 @@
+using FluentAssertions;
+using System;
+using Xunit;
+
+namespace Ardalis.SmartEnum.UnitTests
+{
+    public class SmartEnumComparerAttribute
+    {
+        public class VanillaStringEnum : SmartEnum<VanillaStringEnum, string>
+        {
+            protected VanillaStringEnum(string name, string value) : base(name, value) { }
+
+            public static VanillaStringEnum One = new VanillaStringEnum("One", "one");
+            public static VanillaStringEnum Two = new VanillaStringEnum("Two", "two");
+        }
+
+        [SmartEnumStringComparer(StringComparison.InvariantCultureIgnoreCase)]
+        public class CaseInsensitiveEnum : SmartEnum<CaseInsensitiveEnum, string>
+        {
+            protected CaseInsensitiveEnum(string name, string value) : base(name, value) { }
+
+            public static CaseInsensitiveEnum One = new CaseInsensitiveEnum("One", "one");
+            public static CaseInsensitiveEnum Two = new CaseInsensitiveEnum("Two", "two");
+        }
+
+        [SmartEnumStringComparer(StringComparison.InvariantCulture)]
+        public class CaseSensitiveEnum : SmartEnum<CaseSensitiveEnum, string>
+        {
+            protected CaseSensitiveEnum(string name, string value) : base(name, value) { }
+
+            public static CaseSensitiveEnum One = new CaseSensitiveEnum("One", "one");
+            public static CaseSensitiveEnum Two = new CaseSensitiveEnum("Two", "two");
+        }
+
+        [Fact]
+        public void VanillaStringEnum_FromValue_WhenStringDoesNotMatchCase_DoesNotReturnItem()
+        {
+            //act
+            Assert.Throws<SmartEnumNotFoundException>(() =>
+            {
+                var actual = VanillaStringEnum.FromValue("ONE");
+            });
+        }
+
+        [Fact]
+        public void CaseInsensitiveEnum_FromValue_WhenStringDoesNotMatchCase_ReturnsItem()
+        {
+            //act
+            var actual = CaseInsensitiveEnum.FromValue("ONE");
+
+            //assert
+            actual.Should().Be(CaseInsensitiveEnum.One);
+        }
+
+        [Fact]
+        public void CaseSensitiveEnum_FromValue_WhenStringDoesNotMatchCase_DoesNotReturnItem()
+        {
+            //act
+            Assert.Throws<SmartEnumNotFoundException>(() =>
+            {
+                var actual = CaseSensitiveEnum.FromValue("ONE");
+            });
+        }
+
+        [Fact]
+        public void VanillaStringEnum_FromValue_WhenStringMatchesCase_ReturnsItem()
+        {
+            //act
+            var actual = VanillaStringEnum.FromValue("one");
+
+            //assert
+            actual.Should().Be(VanillaStringEnum.One);
+        }
+
+        [Fact]
+        public void CaseInsensitiveEnum_FromValue_WhenStringMatchesCase_ReturnsItem()
+        {
+            //act
+            var actual = CaseInsensitiveEnum.FromValue("one");
+
+            //assert
+            actual.Should().Be(CaseInsensitiveEnum.One);
+        }
+
+        [Fact]
+        public void CaseSensitiveEnum_FromValue_WhenStringMatchesCase_ReturnsItem()
+        {
+            //act
+            var actual = CaseSensitiveEnum.FromValue("one");
+
+            //assert
+            actual.Should().Be(CaseSensitiveEnum.One);
+        }
+    }
+}

--- a/test/SmartEnum.UnitTests/SmartEnumComparerAttribute.cs
+++ b/test/SmartEnum.UnitTests/SmartEnumComparerAttribute.cs
@@ -33,7 +33,7 @@ namespace Ardalis.SmartEnum.UnitTests
         }
 
         [Fact]
-        public void VanillaStringEnum_FromValue_WhenStringDoesNotMatchCase_DoesNotReturnItem()
+        public void VanillaStringEnum_FromValue_WhenStringDoesNotMatchCase_Throws()
         {
             //act
             Assert.Throws<SmartEnumNotFoundException>(() =>
@@ -53,7 +53,7 @@ namespace Ardalis.SmartEnum.UnitTests
         }
 
         [Fact]
-        public void CaseSensitiveEnum_FromValue_WhenStringDoesNotMatchCase_DoesNotReturnItem()
+        public void CaseSensitiveEnum_FromValue_WhenStringDoesNotMatchCase_Throws()
         {
             //act
             Assert.Throws<SmartEnumNotFoundException>(() =>


### PR DESCRIPTION
As mentioned in #402, I implemented support for case insensitive enums of strings.
The implementation also opens up also other possibilities in terms that a custom equality comparer for enum values can now be specified with a custom attribute