### PR TITLE
Support for NotMappedAttribute on properties

### DIFF
--- a/src/SmartEnum.EFCore/SmartEnumConverterExtensions.cs
+++ b/src/SmartEnum.EFCore/SmartEnumConverterExtensions.cs
@@ -6,7 +6,9 @@ using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 
 namespace SmartEnum.EFCore
@@ -23,6 +25,7 @@ namespace SmartEnum.EFCore
             var propertyTypes = modelBuilder.Model.GetEntityTypes()
                 .SelectMany(e => e.ClrType.GetProperties())
                 .Where(p => TypeUtil.IsDerived(p.PropertyType, typeof(SmartEnum<,>)))
+                .Where(p => p.GetCustomAttribute<NotMappedAttribute>() == null)
                 .Select(p => p.PropertyType)
                 .Distinct();
 
@@ -52,7 +55,8 @@ namespace SmartEnum.EFCore
             foreach (var entityType in modelBuilder.Model.GetEntityTypes())
             {
                 var properties = entityType.ClrType.GetProperties()
-                    .Where(p => TypeUtil.IsDerived(p.PropertyType, typeof(SmartEnum<,>)));
+                    .Where(p => TypeUtil.IsDerived(p.PropertyType, typeof(SmartEnum<,>)))
+                    .Where(p => p.GetCustomAttribute<NotMappedAttribute>() == null);
 
                 foreach (var property in properties)
                 {

--- a/test/SmartEnum.EFCore.IntegrationTests/Entities/SomeEntity.cs
+++ b/test/SmartEnum.EFCore.IntegrationTests/Entities/SomeEntity.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace SmartEnum.EFCore.IntegrationTests.Entities
 {
@@ -23,6 +24,9 @@ namespace SmartEnum.EFCore.IntegrationTests.Entities
         public SomeOuterOwnedEntity OuterOwnedEntity { get; set; }
 
         public List<SomeOwnedEntity> OwnedEntities { get; set; }
+
+        [NotMapped]
+        public TestEnum NotMappedTest { get; set; }
 
         public class Configuration : IEntityTypeConfiguration<SomeEntity>
         {

--- a/test/SmartEnum.EFCore.IntegrationTests/Entities/SomeOuterOwnedEntity.cs
+++ b/test/SmartEnum.EFCore.IntegrationTests/Entities/SomeOuterOwnedEntity.cs
@@ -1,5 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 
+using System.ComponentModel.DataAnnotations.Schema;
+
 namespace SmartEnum.EFCore.IntegrationTests.Entities
 {
     [Owned]
@@ -18,5 +20,8 @@ namespace SmartEnum.EFCore.IntegrationTests.Entities
         public TestBaseEnumWithDerivedValues Test4 { get; set; }
 
         public SomeOwnedEntity InnerOwnedEntity { get; set; }
+
+        [NotMapped]
+        public TestEnum NotMappedTest { get; set; }
     }
 }

--- a/test/SmartEnum.EFCore.IntegrationTests/Entities/SomeOwnedEntity.cs
+++ b/test/SmartEnum.EFCore.IntegrationTests/Entities/SomeOwnedEntity.cs
@@ -1,5 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 
+using System.ComponentModel.DataAnnotations.Schema;
+
 namespace SmartEnum.EFCore.IntegrationTests.Entities
 {
     [Owned]
@@ -16,5 +18,8 @@ namespace SmartEnum.EFCore.IntegrationTests.Entities
         public TestStringEnum Test3 { get; set; }
 
         public TestBaseEnumWithDerivedValues Test4 { get; set; }
+
+        [NotMapped]
+        public TestEnum NotMappedTest { get; set; }
     }
 }

--- a/test/SmartEnum.EFCore.IntegrationTests/SmartEnumEFCoreDbTests.cs
+++ b/test/SmartEnum.EFCore.IntegrationTests/SmartEnumEFCoreDbTests.cs
@@ -85,6 +85,7 @@ namespace SmartEnum.EFCore.IntegrationTests
                 Test2 = TestDerivedEnum.One,
                 Test3 = TestStringEnum.One,
                 Test4 = DerivedTestEnumWithValues1.A,
+                NotMappedTest = TestEnum.One,
                 OwnedEntity = new SomeOwnedEntity
                 {
                     Value = 2,
@@ -143,6 +144,7 @@ namespace SmartEnum.EFCore.IntegrationTests
             entity.Test2.Should().Be(TestDerivedEnum.One);
             entity.Test3.Should().Be(TestStringEnum.One);
             entity.Test4.Should().Be(DerivedTestEnumWithValues1.A);
+            entity.NotMappedTest.Should().BeNull();
 
             entity.OwnedEntity.Value.Should().Be(2);
             entity.OwnedEntity.Weekday.Should().Be(Weekday.Friday);
@@ -150,6 +152,7 @@ namespace SmartEnum.EFCore.IntegrationTests
             entity.OwnedEntity.Test2.Should().Be(TestDerivedEnum.One);
             entity.OwnedEntity.Test3.Should().Be(TestStringEnum.Two);
             entity.OwnedEntity.Test4.Should().Be(DerivedTestEnumWithValues1.B);
+            entity.OwnedEntity.NotMappedTest.Should().BeNull();
 
             entity.OuterOwnedEntity.Value.Should().Be(3);
             entity.OuterOwnedEntity.Weekday.Should().Be(Weekday.Friday);
@@ -157,6 +160,7 @@ namespace SmartEnum.EFCore.IntegrationTests
             entity.OuterOwnedEntity.Test2.Should().Be(TestDerivedEnum.One);
             entity.OuterOwnedEntity.Test3.Should().Be(TestStringEnum.Two);
             entity.OuterOwnedEntity.Test4.Should().Be(DerivedTestEnumWithValues1.B);
+            entity.OuterOwnedEntity.NotMappedTest.Should().BeNull();
 
             entity.OuterOwnedEntity.InnerOwnedEntity.Value.Should().Be(4);
             entity.OuterOwnedEntity.InnerOwnedEntity.Weekday.Should().Be(Weekday.Friday);
@@ -164,6 +168,7 @@ namespace SmartEnum.EFCore.IntegrationTests
             entity.OuterOwnedEntity.InnerOwnedEntity.Test2.Should().Be(TestDerivedEnum.One);
             entity.OuterOwnedEntity.InnerOwnedEntity.Test3.Should().Be(TestStringEnum.Two);
             entity.OuterOwnedEntity.InnerOwnedEntity.Test4.Should().Be(DerivedTestEnumWithValues1.B);
+            entity.OuterOwnedEntity.InnerOwnedEntity.NotMappedTest.Should().BeNull();
 
             entity.OwnedEntities.Should().SatisfyRespectively(
                 o =>
@@ -174,6 +179,7 @@ namespace SmartEnum.EFCore.IntegrationTests
                     o.Test2.Should().Be(TestDerivedEnum.One);
                     o.Test3.Should().Be(TestStringEnum.Three);
                     o.Test4.Should().Be(DerivedTestEnumWithValues1.A);
+                    o.NotMappedTest.Should().BeNull();
                 },
                 o =>
                 {
@@ -183,6 +189,7 @@ namespace SmartEnum.EFCore.IntegrationTests
                     o.Test2.Should().Be(TestDerivedEnum.One);
                     o.Test3.Should().Be(TestStringEnum.One);
                     o.Test4.Should().Be(DerivedTestEnumWithValues1.B);
+                    o.NotMappedTest.Should().BeNull();
                 });
         }
     }


### PR DESCRIPTION
Properties from entities marked with the `[NotMapped]` attribute should not be included to the `EntityTypeBuilder`.