### PR TITLE
Fix icon.png when creating nuget package

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,6 +15,7 @@
 		<Features>strict</Features>
 	</PropertyGroup>
 	<PropertyGroup>
+		<SolutionDir Condition="'$(SolutionDir)'==''">$(MSBuildThisFileDirectory)</SolutionDir>
 		<RepoRelativeProjectDir>$([MSBuild]::MakeRelative($(RepoRoot), $(MSBuildProjectDirectory)))</RepoRelativeProjectDir>
 
 		<!-- Define useful flags based on project name conventions -->


### PR DESCRIPTION
The `$(SolutionDir)` is not correctly set or somehow not available anymore. I've added it to the .props file, when not already set.

Hope this helps to create a new version of the package.