### PR TITLE
449: Support JSON serialization of ushort SmartEnums

### DIFF
--- a/src/SmartEnum.SystemTextJson/SmartFlagEnumValueConverter.cs
+++ b/src/SmartEnum.SystemTextJson/SmartFlagEnumValueConverter.cs
@@ -97,7 +97,7 @@ where TValue: struct, IEquatable<TValue>, IComparable<TValue>
         else if (typeof(TValue) == typeof(bool))
             writer.WriteBooleanValue((bool)(object)value.Value);
         else if (typeof(TValue) == typeof(short))
-            writer.WriteNumberValue((int)(short)(object)value.Value);
+            writer.WriteNumberValue((short)(object)value.Value);
         else if (typeof(TValue) == typeof(int))
             writer.WriteNumberValue((int)(object)value.Value);
         else if (typeof(TValue) == typeof(double))
@@ -106,6 +106,8 @@ where TValue: struct, IEquatable<TValue>, IComparable<TValue>
             writer.WriteNumberValue((decimal)(object)value.Value);
         else if (typeof(TValue) == typeof(ulong))
             writer.WriteNumberValue((ulong)(object)value.Value);
+        else if (typeof(TValue) == typeof(ushort))
+            writer.WriteNumberValue((ushort)(object)value.Value);
         else if (typeof(TValue) == typeof(uint))
             writer.WriteNumberValue((uint)(object)value.Value);
         else if (typeof(TValue) == typeof(float))

--- a/src/SmartEnum.SystemTextJson/SmartFlagEnumValueConverter.cs
+++ b/src/SmartEnum.SystemTextJson/SmartFlagEnumValueConverter.cs
@@ -1,7 +1,6 @@
 namespace Ardalis.SmartEnum.SystemTextJson
 {
     using System;
-    using System.Linq;
     using System.Text.Json;
     using System.Text.Json.Serialization;
 
@@ -75,7 +74,7 @@ namespace Ardalis.SmartEnum.SystemTextJson
             else if (typeof(TValue) == typeof(bool))
                 writer.WriteBooleanValue((bool)(object)value.Value);
             else if (typeof(TValue) == typeof(short))
-                writer.WriteNumberValue((int)(short)(object)value.Value);
+                writer.WriteNumberValue((short)(object)value.Value);
             else if (typeof(TValue) == typeof(int))
                 writer.WriteNumberValue((int)(object)value.Value);
             else if (typeof(TValue) == typeof(double))
@@ -90,6 +89,8 @@ namespace Ardalis.SmartEnum.SystemTextJson
                 writer.WriteNumberValue((float)(object)value.Value);
             else if (typeof(TValue) == typeof(long))
                 writer.WriteNumberValue((long)(object)value.Value);
+            else if (typeof(TValue) == typeof(ushort))
+                writer.WriteNumberValue((ushort)(object)value.Value);
             else
                 writer.WriteStringValue(value.Value.ToString());
         }

--- a/test/SmartEnum.SystemTextJson.UnitTests/FlagTestEnums.cs
+++ b/test/SmartEnum.SystemTextJson.UnitTests/FlagTestEnums.cs
@@ -1,5 +1,12 @@
 namespace Ardalis.SmartEnum.SystemTextJson.UnitTests
 {
+    public sealed class FlagTestEnumUnsignedInt16 : SmartFlagEnum<FlagTestEnumUnsignedInt16, ushort>
+    {
+        public static readonly FlagTestEnumUnsignedInt16 Instance = new(nameof(Instance), 12);
+
+        FlagTestEnumUnsignedInt16(string name, ushort value) : base(name, value) { }
+    }
+
     public sealed class FlagTestEnumInt16 : SmartFlagEnum<FlagTestEnumInt16, short>
     {
         public static readonly FlagTestEnumInt16 Instance = new FlagTestEnumInt16(nameof(Instance), 1);

--- a/test/SmartEnum.SystemTextJson.UnitTests/SmartFlagEnumValueConverterTests.cs
+++ b/test/SmartEnum.SystemTextJson.UnitTests/SmartFlagEnumValueConverterTests.cs
@@ -1,4 +1,3 @@
-using Ardalis.SmartEnum;
 using FluentAssertions;
 using System;
 using System.Text.Json;
@@ -11,6 +10,9 @@ namespace Ardalis.SmartEnum.SystemTextJson.UnitTests
     {
         public class TestClass
         {
+            [JsonConverter(typeof(SmartFlagEnumValueConverter<FlagTestEnumUnsignedInt16, ushort>))]
+            public FlagTestEnumUnsignedInt16 UnsignedInt16 { get; set; }
+
             [JsonConverter(typeof(SmartFlagEnumValueConverter<FlagTestEnumInt16, short>))]
             public FlagTestEnumInt16 Int16 { get; set; }
 
@@ -21,8 +23,9 @@ namespace Ardalis.SmartEnum.SystemTextJson.UnitTests
             public FlagTestEnumDouble Double { get; set; }
         }
 
-        static readonly TestClass TestInstance = new TestClass
+        static readonly TestClass TestInstance = new()
         {
+            UnsignedInt16 = FlagTestEnumUnsignedInt16.Instance,
             Int16 = FlagTestEnumInt16.Instance,
             Int32 = FlagTestEnumInt32.Instance2,
             Double = FlagTestEnumDouble.Instance
@@ -30,6 +33,7 @@ namespace Ardalis.SmartEnum.SystemTextJson.UnitTests
 
         static readonly string JsonString = JsonSerializer.Serialize(new
         {
+            UnsignedInt16 = 12,
             Int16 = 1,
             Int32 = 2,
             Double = 1


### PR DESCRIPTION
- Fixes #449
- `ushort` `SmartEnum` types are now supported in `System.Text.Json` writing/serialization