### PR TITLE
Reverted PR 412

### DIFF
--- a/src/SmartEnum/SmartEnum.cs
+++ b/src/SmartEnum/SmartEnum.cs
@@ -60,8 +60,7 @@ namespace Ardalis.SmartEnum
                 var dictionary = new Dictionary<TValue, TEnum>(GetValueComparer());
                 foreach (var item in _enumOptions.Value)
                 {
-                    if (item._value != null && !dictionary.ContainsKey(item._value))
-                        dictionary.Add(item._value, item);
+                    dictionary.TryAdd(item._value, item);
                 }
                 return dictionary;
             });
@@ -105,6 +104,9 @@ namespace Ardalis.SmartEnum
         {
             if (String.IsNullOrEmpty(name))
                 ThrowHelper.ThrowArgumentNullOrEmptyException(nameof(name));
+
+            if (value is null)
+                ThrowHelper.ThrowArgumentNullException(nameof(value));
 
             _name = name;
             _value = value;
@@ -216,22 +218,12 @@ namespace Ardalis.SmartEnum
         /// <seealso cref="SmartEnum{TEnum, TValue}.TryFromValue(TValue, out TEnum)"/>
         public static TEnum FromValue(TValue value)
         {
-            TEnum result;
+            if (value is null)
+                ThrowHelper.ThrowArgumentNullException(nameof(value));
 
-            if (value != null)
+            if (!_fromValue.Value.TryGetValue(value, out var result))
             {
-                if (!_fromValue.Value.TryGetValue(value, out result))
-                {
-                    ThrowHelper.ThrowValueNotFoundException<TEnum, TValue>(value);
-                }
-            }
-            else
-            {
-                result = _enumOptions.Value.FirstOrDefault(x => x.Value == null);
-                if (result == null)
-                {
-                    ThrowHelper.ThrowValueNotFoundException<TEnum, TValue>(value);
-                }
+                ThrowHelper.ThrowValueNotFoundException<TEnum, TValue>(value);
             }
             return result;
         }

--- a/test/SmartEnum.UnitTests/SmartEnumStringFromValue.cs
+++ b/test/SmartEnum.UnitTests/SmartEnumStringFromValue.cs
@@ -23,18 +23,10 @@ namespace Ardalis.SmartEnum.UnitTests
         }
 
         [Fact]
-        public void ReturnsEnumGivenMatchingNullValue()
+        public void ThrowsGivenNonMatchingValue()
         {
-            var result = TestNullableStringEnum.FromValue(null);
+            var value = string.Empty;
 
-            result.Should().BeSameAs(TestNullableStringEnum.None);
-        }
-
-        [Theory]
-        [InlineData("invalid")]
-        [InlineData(null)]
-        public void ThrowsGivenNonMatchingValue(string value)
-        {
             Action action = () => TestStringEnum.FromValue(value);
 
             action.Should()

--- a/test/SmartEnum.UnitTests/TestEnum.cs
+++ b/test/SmartEnum.UnitTests/TestEnum.cs
@@ -46,18 +46,8 @@ namespace Ardalis.SmartEnum.UnitTests
         public static readonly TestStringEnum One = new TestStringEnum(nameof(One), nameof(One));
         public static readonly TestStringEnum Two = new TestStringEnum(nameof(Two), nameof(Two));
         public static readonly TestStringEnum Three = new TestStringEnum(nameof(Three), nameof(Three));
-        public static readonly TestStringEnum Empty = new TestStringEnum(nameof(Empty), string.Empty);
 
         protected TestStringEnum(string name, string value) : base(name, value)
-        {
-        }
-    }
-
-    public class TestNullableStringEnum : SmartEnum<TestNullableStringEnum, string>
-    {
-        public static readonly TestNullableStringEnum None = new TestNullableStringEnum(nameof(None), null);
-
-        protected TestNullableStringEnum(string name, string value) : base(name, value)
         {
         }
     }


### PR DESCRIPTION
Fixes #512.

As described in the issue, allowing null for `Value` breaks the assumed contract and leads to various inconsistencies.
On top of that, the internal implementation assumes the `Value` won't be null. The equality operators, hash code, implicit/explicit operators, all of them are based on the premise that the `Value` is not null.

If the consumers need null (e.g. database columns), then the whole thing can be null, e.g. `MyEnum?`. But, once you have an instance of the enum, we should guarantee a non-null `Value` field.

The PR #412 was merged and published as part of version 8 (not so long ago). If needed we can keep this PR open, until a larger consensus is reached on this topic.

PS. The `Name` indeed can be empty, or eventually null. We may add support for that I assume. Actually, that was the original request in this issue #302.