### PR TITLE
Fix case insensitive name comparison bug

### DIFF
--- a/src/SmartEnum/SmartFlagEnum.cs
+++ b/src/SmartEnum/SmartFlagEnum.cs
@@ -46,9 +46,6 @@ namespace Ardalis.SmartEnum
         static readonly Lazy<Dictionary<string, TEnum>> _fromName =
             new Lazy<Dictionary<string, TEnum>>(() => GetAllOptions().ToDictionary(item => item.Name));
 
-        static readonly Lazy<Dictionary<string, TEnum>> _fromNameIgnoreCase =
-            new Lazy<Dictionary<string, TEnum>>(() => GetAllOptions().ToDictionary(item => item.Name, StringComparer.OrdinalIgnoreCase));
-
         private static IEnumerable<TEnum> GetAllOptions()
         {
             Type baseType = typeof(TEnum);
@@ -123,19 +120,12 @@ namespace Ardalis.SmartEnum
             if (String.IsNullOrEmpty(names))
                 ThrowHelper.ThrowArgumentNullOrEmptyException(nameof(names));
 
-            if (ignoreCase)
-                return FromName(_fromNameIgnoreCase.Value);
-            else
-                return FromName(_fromName.Value);
-
-            IEnumerable<TEnum> FromName(Dictionary<string, TEnum> dictionary)
+            if (!_fromName.Value.TryGetFlagEnumValuesByName<TEnum, TValue>(names, ignoreCase, out var result))
             {
-                if (!dictionary.TryGetFlagEnumValuesByName<TEnum, TValue>(names, out var result))
-                {
-                    ThrowHelper.ThrowNameNotFoundException<TEnum, TValue>(names);
-                }
-                return result;
+                ThrowHelper.ThrowNameNotFoundException<TEnum, TValue>(names);
             }
+
+            return result;
         }
 
         /// <summary>
@@ -170,10 +160,7 @@ namespace Ardalis.SmartEnum
             if (String.IsNullOrEmpty(names))
                 ThrowHelper.ThrowArgumentNullOrEmptyException(nameof(names));
 
-            if (ignoreCase)
-                return _fromNameIgnoreCase.Value.TryGetFlagEnumValuesByName<TEnum, TValue>(names, out result);
-            else
-                return _fromName.Value.TryGetFlagEnumValuesByName<TEnum, TValue>(names, out result);
+            return _fromName.Value.TryGetFlagEnumValuesByName<TEnum, TValue>(names, ignoreCase, out result);
         }
 
         /// <summary>

--- a/src/SmartEnum/SmartFlagEnumExtensions.cs
+++ b/src/SmartEnum/SmartFlagEnumExtensions.cs
@@ -57,18 +57,19 @@ namespace Ardalis.SmartEnum
         /// <param name="names"></param>
         /// <param name="outputEnums"></param>
         /// <returns></returns>
-        public static bool TryGetFlagEnumValuesByName<TEnum, TValue>(this Dictionary<string, TEnum> dictionary, string names, out IEnumerable<TEnum> outputEnums)
+        public static bool TryGetFlagEnumValuesByName<TEnum, TValue>(this Dictionary<string, TEnum> dictionary, string names, bool ignoreCase, out IEnumerable<TEnum> outputEnums)
             where TEnum : SmartFlagEnum<TEnum, TValue>
             where TValue : IEquatable<TValue>, IComparable<TValue>
         {
             var outputList = new List<TEnum>(dictionary.Count);
 
             var commaSplitNameList = names.Replace(" ", "").Trim().Split(',');
-            Array.Sort(commaSplitNameList);
+            var nameComparer = ignoreCase ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+            Array.Sort(commaSplitNameList, nameComparer);
 
             foreach (var enumValue in dictionary.Values)
             {
-                var result = Array.BinarySearch(commaSplitNameList, enumValue.Name);
+                var result = Array.BinarySearch(commaSplitNameList, enumValue.Name, nameComparer);
                 if (result >= 0)
                 {
                     outputList.Add(enumValue);

--- a/test/SmartEnum.UnitTests/SmartEnumFromName.cs
+++ b/test/SmartEnum.UnitTests/SmartEnumFromName.cs
@@ -35,6 +35,14 @@ namespace Ardalis.SmartEnum.UnitTests
         }
 
         [Fact]
+        public void ReturnsEnumGivenMatchingNameIgnoreCase()
+        {
+            var result = TestEnum.FromName("ONE", true);
+
+            result.Should().BeSameAs(TestEnum.One);
+        }
+
+        [Fact]
         public void ReturnsEnumGivenDerivedClass()
         {
             var result = TestDerivedEnum.FromName("One");

--- a/test/SmartFlagEnum.UnitTests/SmartFlagEnumFromName.cs
+++ b/test/SmartFlagEnum.UnitTests/SmartFlagEnumFromName.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -14,7 +14,7 @@ namespace Ardalis.SmartFlagEnum.UnitTests
         [Fact]
         public void IgnoreCaseReturnsIEnumerableWithSameValues()
         {
-            var result = SmartFlagTestEnum.FromName("One, Two", true).ToList();
+            var result = SmartFlagTestEnum.FromName("ONE, TWO", true).ToList();
 
             Assert.Equal("One", result[0].Name);
             Assert.Equal("Two", result[1].Name);


### PR DESCRIPTION
`SmartFlagEnum` doesn't use a proper `IStringComparer` in `TryGetFlagEnumValuesByName` implementation, hence bugs when using `FromName`/`TryFromName` with `ignoreCase=true`.