### PR TITLE
TEnum[] to List<TEnum> for webassembly compatibility issue in .net 9

### DIFF
--- a/src/SmartEnum/SmartEnum.cs
+++ b/src/SmartEnum/SmartEnum.cs
@@ -45,8 +45,8 @@ namespace Ardalis.SmartEnum
         where TEnum : SmartEnum<TEnum, TValue>
         where TValue : IEquatable<TValue>, IComparable<TValue>
     {
-        static readonly Lazy<TEnum[]> _enumOptions =
-            new Lazy<TEnum[]>(GetAllOptions, LazyThreadSafetyMode.ExecutionAndPublication);
+        static readonly Lazy<List<TEnum>> _enumOptions =
+            new Lazy<List<TEnum>>(GetAllOptions, LazyThreadSafetyMode.ExecutionAndPublication);
 
         static readonly Lazy<Dictionary<string, TEnum>> _fromName =
             new Lazy<Dictionary<string, TEnum>>(() => _enumOptions.Value.ToDictionary(item => item.Name));
@@ -67,7 +67,7 @@ namespace Ardalis.SmartEnum
                 return dictionary;
             });
 
-        private static TEnum[] GetAllOptions()
+        private static List<TEnum> GetAllOptions()
         {
             Type baseType = typeof(TEnum);
             return Assembly.GetAssembly(baseType)
@@ -75,7 +75,7 @@ namespace Ardalis.SmartEnum
                 .Where(t => baseType.IsAssignableFrom(t))
                 .SelectMany(t => t.GetFieldsOfType<TEnum>())
                 .OrderBy(t => t.Name)
-                .ToArray();
+                .ToList();
         }
 
         private static IEqualityComparer<TValue> GetValueComparer()


### PR DESCRIPTION
@ardalis I confirmed this change fixes the issue, as suggested by @DataByte-James in #556. Seems to be a quirk with .NET 9 webassembly/mono runtime that affects arrays, and not lists. This issue is looking like it will be addressed by MS too.. (https://github.com/dotnet/runtime/issues/109931) but this change should have no negative impact.

Hopefully this could get a quick review if possible.

Thank you